### PR TITLE
Feat/study application #48

### DIFF
--- a/src/main/java/com/mos/backend/common/infrastructure/EntityFacade.java
+++ b/src/main/java/com/mos/backend/common/infrastructure/EntityFacade.java
@@ -1,6 +1,11 @@
 package com.mos.backend.common.infrastructure;
 
 import com.mos.backend.common.exception.MosException;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studies.entity.exception.StudyErrorCode;
+import com.mos.backend.studies.infrastructure.StudyRepository;
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+import com.mos.backend.studyparticipations.infrastructure.StudyApplicationRepository;
 import com.mos.backend.users.entity.User;
 import com.mos.backend.users.entity.exception.UserErrorCode;
 import com.mos.backend.users.infrastructure.respository.UserRepository;
@@ -13,9 +18,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class EntityFacade {
     private final UserRepository userRepository;
+    private final StudyRepository studyRepository;
+    private final StudyApplicationRepository studyApplicationRepository;
 
     public User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MosException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public Study getStudy(Long studyId) {
+        return studyRepository.findById(studyId)
+                .orElseThrow(() -> new MosException(StudyErrorCode.STUDY_NOT_FOUND));
+    }
+
+    public StudyApplication getStudyApplication(Long studyApplicationId) {
+        return studyApplicationRepository.findById(studyApplicationId)
+                .orElseThrow(() -> new MosException(StudyErrorCode.STUDY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/mos/backend/common/infrastructure/EntityFacade.java
+++ b/src/main/java/com/mos/backend/common/infrastructure/EntityFacade.java
@@ -3,7 +3,7 @@ package com.mos.backend.common.infrastructure;
 import com.mos.backend.common.exception.MosException;
 import com.mos.backend.users.entity.User;
 import com.mos.backend.users.entity.exception.UserErrorCode;
-import com.mos.backend.users.infrastructure.respository.UserRepositoryImpl;
+import com.mos.backend.users.infrastructure.respository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Service
 public class EntityFacade {
-    private final UserRepositoryImpl userRepository;
+    private final UserRepository userRepository;
 
     public User getUser(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/com/mos/backend/studymembers/application/StudyMemberService.java
+++ b/src/main/java/com/mos/backend/studymembers/application/StudyMemberService.java
@@ -1,14 +1,10 @@
 package com.mos.backend.studymembers.application;
 
-import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
 import com.mos.backend.studies.entity.Study;
-import com.mos.backend.studies.entity.exception.StudyErrorCode;
-import com.mos.backend.studies.infrastructure.StudyRepository;
 import com.mos.backend.studymembers.entity.StudyMember;
 import com.mos.backend.studymembers.infrastructure.StudyMemberRepository;
 import com.mos.backend.users.entity.User;
-import com.mos.backend.users.entity.exception.UserErrorCode;
-import com.mos.backend.users.infrastructure.respository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,22 +14,13 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class StudyMemberService {
 
-    private final StudyRepository studyRepository;
-    private final UserRepository userRepository;
     private final StudyMemberRepository studyMemberRepository;
+    private final EntityFacade entityFacade;
 
     public void create(Long studyId, Long userId) {
-        Study study = getStudyById(studyId);
-        User user = getUserById(userId);
+        Study study = entityFacade.getStudy(studyId);
+        User user = entityFacade.getUser(userId);
 
         studyMemberRepository.save(StudyMember.create(study, user));
-    }
-
-    private Study getStudyById(Long studyId) {
-        return studyRepository.findById(studyId).orElseThrow(() -> new MosException(StudyErrorCode.STUDY_NOT_FOUND));
-    }
-
-    private User getUserById(Long userId) {
-        return userRepository.findById(userId).orElseThrow(() -> new MosException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/mos/backend/studymembers/entity/exception/StudyMemberErrorCode.java
+++ b/src/main/java/com/mos/backend/studymembers/entity/exception/StudyMemberErrorCode.java
@@ -1,0 +1,32 @@
+package com.mos.backend.studymembers.entity.exception;
+
+import com.mos.backend.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+
+import java.util.Locale;
+
+@RequiredArgsConstructor
+public enum StudyMemberErrorCode implements ErrorCode {
+    STUDY_MEMBER_FULL(HttpStatus.BAD_REQUEST, "auth.study-member.full");
+
+    private final HttpStatus httpStatus;
+    private final String messageKey;
+
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getErrorName() {
+        return this.name();
+    }
+
+    @Override
+    public String getMessage(MessageSource messageSource) {
+        return messageSource.getMessage(messageKey, null, Locale.getDefault());
+    }
+}

--- a/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberJpaRepository.java
+++ b/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberJpaRepository.java
@@ -1,7 +1,9 @@
 package com.mos.backend.studymembers.infrastructure;
 
+import com.mos.backend.studies.entity.Study;
 import com.mos.backend.studymembers.entity.StudyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyMemberJpaRepository extends JpaRepository<StudyMember, Long> {
+    long countByStudy(Study study);
 }

--- a/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberRepository.java
+++ b/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberRepository.java
@@ -1,8 +1,10 @@
 package com.mos.backend.studymembers.infrastructure;
 
+import com.mos.backend.studies.entity.Study;
 import com.mos.backend.studymembers.entity.StudyMember;
 
 public interface StudyMemberRepository {
 
     StudyMember save(StudyMember studyMember);
+    long countByStudy(Study study);
 }

--- a/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/studymembers/infrastructure/StudyMemberRepositoryImpl.java
@@ -1,12 +1,13 @@
 package com.mos.backend.studymembers.infrastructure;
 
+import com.mos.backend.studies.entity.Study;
 import com.mos.backend.studymembers.entity.StudyMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class StudyMemberRepositoryImpl implements StudyMemberRepository{
+public class StudyMemberRepositoryImpl implements StudyMemberRepository {
 
     private final StudyMemberJpaRepository studyMemberJpaRepository;
 
@@ -14,5 +15,10 @@ public class StudyMemberRepositoryImpl implements StudyMemberRepository{
     @Override
     public StudyMember save(StudyMember studyMember) {
         return studyMemberJpaRepository.save(studyMember);
+    }
+
+    @Override
+    public long countByStudy(Study study) {
+        return studyMemberJpaRepository.countByStudy(study);
     }
 }

--- a/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
+++ b/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
@@ -29,7 +29,7 @@ public class StudyApplicationService {
     }
 
     @Transactional
-    public void approveStudyMember(Long userId, Long studyApplicationId) {
+    public void approveStudyApplication(Long userId, Long studyApplicationId) {
         User user = entityFacade.getUser(userId);
         StudyApplication studyApplication = entityFacade.getStudyApplication(studyApplicationId);
 

--- a/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
+++ b/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
@@ -41,6 +41,14 @@ public class StudyApplicationService {
         handleApprove(studyApplication, study, user);
     }
 
+    @Transactional
+    public void rejectStudyApplication(Long userId, Long studyApplicationId) {
+        User user = entityFacade.getUser(userId);
+        StudyApplication studyApplication = entityFacade.getStudyApplication(studyApplicationId);
+
+        studyApplication.reject();
+    }
+
     private static void validateStudyMemberCnt(long studyMemberCnt, Study study) {
         if (studyMemberCnt == 0)
             throw new MosException(StudyErrorCode.STUDY_NOT_FOUND);

--- a/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
+++ b/src/main/java/com/mos/backend/studyparticipations/application/StudyApplicationService.java
@@ -1,0 +1,56 @@
+package com.mos.backend.studyparticipations.application;
+
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studies.entity.exception.StudyErrorCode;
+import com.mos.backend.studymembers.entity.StudyMember;
+import com.mos.backend.studymembers.entity.exception.StudyMemberErrorCode;
+import com.mos.backend.studymembers.infrastructure.StudyMemberRepository;
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+import com.mos.backend.users.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyApplicationService {
+
+    private final StudyMemberRepository studyMemberRepository;
+    private final EntityFacade entityFacade;
+
+    @Transactional
+    public void create(Long studyId, Long userId) {
+        Study study = entityFacade.getStudy(studyId);
+        User user = entityFacade.getUser(userId);
+
+        studyMemberRepository.save(StudyMember.create(study, user));
+    }
+
+    @Transactional
+    public void approveStudyMember(Long userId, Long studyApplicationId) {
+        User user = entityFacade.getUser(userId);
+        StudyApplication studyApplication = entityFacade.getStudyApplication(studyApplicationId);
+
+        Study study = studyApplication.getStudy();
+        long studyMemberCnt = studyMemberRepository.countByStudy(study);
+
+        validateStudyMemberCnt(studyMemberCnt, study);
+
+        handleApprove(studyApplication, study, user);
+    }
+
+    private static void validateStudyMemberCnt(long studyMemberCnt, Study study) {
+        if (studyMemberCnt == 0)
+            throw new MosException(StudyErrorCode.STUDY_NOT_FOUND);
+
+        if (studyMemberCnt >= study.getMaxParticipantsCount())
+            throw new MosException(StudyMemberErrorCode.STUDY_MEMBER_FULL);
+    }
+
+    private void handleApprove(StudyApplication studyApplication, Study study, User user) {
+        studyApplication.approve();
+        studyMemberRepository.save(StudyMember.create(study, user));
+    }
+}

--- a/src/main/java/com/mos/backend/studyparticipations/entity/StudyApplication.java
+++ b/src/main/java/com/mos/backend/studyparticipations/entity/StudyApplication.java
@@ -32,4 +32,8 @@ public class StudyApplication extends BaseAuditableEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StudyApplicationStatus status;
+
+    public void approve() {
+        this.status = StudyApplicationStatus.APPROVED;
+    }
 }

--- a/src/main/java/com/mos/backend/studyparticipations/entity/StudyApplication.java
+++ b/src/main/java/com/mos/backend/studyparticipations/entity/StudyApplication.java
@@ -36,4 +36,8 @@ public class StudyApplication extends BaseAuditableEntity {
     public void approve() {
         this.status = StudyApplicationStatus.APPROVED;
     }
+
+    public void reject() {
+        this.status = StudyApplicationStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationJpaRepository.java
+++ b/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationJpaRepository.java
@@ -1,0 +1,7 @@
+package com.mos.backend.studyparticipations.infrastructure;
+
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyApplicationJpaRepository extends JpaRepository<StudyApplication, Long> {
+}

--- a/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationRepository.java
+++ b/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationRepository.java
@@ -1,0 +1,9 @@
+package com.mos.backend.studyparticipations.infrastructure;
+
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+
+import java.util.Optional;
+
+public interface StudyApplicationRepository {
+    Optional<StudyApplication> findById(Long studyApplicationId);
+}

--- a/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/studyparticipations/infrastructure/StudyApplicationRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.mos.backend.studyparticipations.infrastructure;
+
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyApplicationRepositoryImpl implements StudyApplicationRepository {
+    private final StudyApplicationJpaRepository studyApplicationJpaRepository;
+
+    @Override
+    public Optional<StudyApplication> findById(Long studyApplicationId) {
+        return studyApplicationJpaRepository.findById(studyApplicationId);
+    }
+}

--- a/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
+++ b/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
@@ -1,0 +1,21 @@
+package com.mos.backend.studyparticipations.presentation.controller.api;
+
+import com.mos.backend.studyparticipations.application.StudyApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/study-applications")
+@RestController
+public class StudyApplicationController {
+
+    private final StudyApplicationService studyApplicationService;
+
+    @PutMapping("/{studyApplicationId}/approval")
+    public ResponseEntity<Void> approveStudyMember(@AuthenticationPrincipal Long userId, @PathVariable Long studyApplicationId) {
+        studyApplicationService.approveStudyMember(userId, studyApplicationId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
+++ b/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
@@ -18,4 +18,10 @@ public class StudyApplicationController {
         studyApplicationService.approveStudyApplication(userId, studyApplicationId);
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("/{studyApplicationId}/rejection")
+    public ResponseEntity<Void> rejectStudyApplication(@AuthenticationPrincipal Long userId, @PathVariable Long studyApplicationId) {
+        studyApplicationService.rejectStudyApplication(userId, studyApplicationId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
+++ b/src/main/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationController.java
@@ -14,8 +14,8 @@ public class StudyApplicationController {
     private final StudyApplicationService studyApplicationService;
 
     @PutMapping("/{studyApplicationId}/approval")
-    public ResponseEntity<Void> approveStudyMember(@AuthenticationPrincipal Long userId, @PathVariable Long studyApplicationId) {
-        studyApplicationService.approveStudyMember(userId, studyApplicationId);
+    public ResponseEntity<Void> approveStudyApplication(@AuthenticationPrincipal Long userId, @PathVariable Long studyApplicationId) {
+        studyApplicationService.approveStudyApplication(userId, studyApplicationId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/mos/backend/studyquestions/application/StudyQuestionService.java
+++ b/src/main/java/com/mos/backend/studyquestions/application/StudyQuestionService.java
@@ -65,7 +65,7 @@ public class StudyQuestionService {
     private StudyQuestion convertToEntity(Study study, StudyQuestionCreateRequestDto dto) {
         return StudyQuestion.create(
                 study,
-                dto.getQuestionId(),
+                dto.getQuestionNum(),
                 dto.getQuestion(),
                 QuestionType.fromDescription(dto.getType()),
                 QuestionOption.fromList(dto.getOptions()),

--- a/src/main/java/com/mos/backend/studyquestions/entity/StudyQuestion.java
+++ b/src/main/java/com/mos/backend/studyquestions/entity/StudyQuestion.java
@@ -25,7 +25,7 @@ public class StudyQuestion extends BaseAuditableEntity {
     private Study study;
 
     @Column(nullable = false)
-    private Long questionId;
+    private Long questionNum;
 
     @Column(nullable = false)
     private String question;
@@ -42,7 +42,7 @@ public class StudyQuestion extends BaseAuditableEntity {
     public static StudyQuestion create(Study study, Long questionId, String question, QuestionType type, QuestionOption options, boolean required) {
         StudyQuestion studyQuestion = new StudyQuestion();
         studyQuestion.study = study;
-        studyQuestion.questionId = questionId;
+        studyQuestion.questionNum = questionId;
         studyQuestion.question = question;
         studyQuestion.type = type;
         studyQuestion.options = options;

--- a/src/main/java/com/mos/backend/studyquestions/presentation/requestdto/StudyQuestionCreateRequestDto.java
+++ b/src/main/java/com/mos/backend/studyquestions/presentation/requestdto/StudyQuestionCreateRequestDto.java
@@ -18,7 +18,7 @@ public class StudyQuestionCreateRequestDto {
     private String question;
     @NotNull(message = "questionId는 필수입니다.")
     @Min(value = 1, message = "questionId는 1보다 커야합니다.")
-    private Long questionId;
+    private Long questionNum;
     @NotNull(message = "isRequired 필수입니다.")
     private boolean isRequired;
     @NotBlank(message = "type 필수입니다.")

--- a/src/main/resources/messages/messages-error.properties
+++ b/src/main/resources/messages/messages-error.properties
@@ -9,6 +9,7 @@ auth.user.expired-access-token = \uC561\uC138\uC2A4 \uD1A0\uD070\uC774 \uB9CC\uB
 # Study
 study.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514\uC785\uB2C8\uB2E4.
 study.invalid-recruitment-dates=\uBAA8\uC9D1 \uB9C8\uAC10 \uB0A0\uC9DC\uB294 \uC2DC\uC791 \uB0A0\uC9DC\uBCF4\uB2E4 \uBE60\uB97C \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
+
 ## Study - Category
 study.category.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uCE74\uD14C\uACE0\uB9AC\uC785\uB2C8\uB2E4.
 study.meeting-type.invalid=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 meetingType\uC785\uB2C8\uB2E4.
@@ -16,3 +17,6 @@ study.meeting-type.invalid=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 meetingType\uC7
 # Study - Question
 study-question.invalid-question-type=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 \uC9C8\uBB38 \uC720\uD615\uC785\uB2C8\uB2E4.
 study-question.invalid-multiple-choice-options=\uAC1D\uAD00\uC2DD\uC758 \uC120\uC9C0\uB294 \uB450 \uAC1C \uC774\uC0C1\uC785\uB2C8\uB2E4.
+
+# Study - Member
+auth.study-member.full=\uC2A4\uD130\uB514 \uBA64\uBC84\uAC00 \uAF49 \uCC3C\uC2B5\uB2C8\uB2E4.

--- a/src/test/java/com/mos/backend/studycurriculum/application/StudyCurriculumServiceTest.java
+++ b/src/test/java/com/mos/backend/studycurriculum/application/StudyCurriculumServiceTest.java
@@ -1,6 +1,7 @@
 package com.mos.backend.studycurriculum.application;
 
 import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
 import com.mos.backend.studies.entity.Study;
 import com.mos.backend.studies.entity.exception.StudyErrorCode;
 import com.mos.backend.studies.infrastructure.StudyRepository;
@@ -37,6 +38,9 @@ class StudyCurriculumServiceTest {
     @Mock
     private StudyMemberRepository studyMemberRepository;
 
+    @Mock
+    private EntityFacade entityFacade;
+
     @InjectMocks
     private StudyMemberService studyMemberService;
 
@@ -52,15 +56,15 @@ class StudyCurriculumServiceTest {
             Study mockStudy = mock(Study.class);
             User mockUser = mock(User.class);
 
-            when(studyRepository.findById(studyId)).thenReturn(Optional.of(mockStudy));
-            when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+            when(entityFacade.getStudy(studyId)).thenReturn(mockStudy);
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
 
             // When
             studyMemberService.create(studyId, userId);
 
             // Then
-            verify(studyRepository).findById(studyId);
-            verify(userRepository).findById(userId);
+            verify(entityFacade).getStudy(studyId);
+            verify(entityFacade).getUser(userId);
             verify(studyMemberRepository).save(any(StudyMember.class));
         }
     }
@@ -75,7 +79,7 @@ class StudyCurriculumServiceTest {
             Long studyId = 1L;
             Long userId = 1L;
 
-            when(studyRepository.findById(studyId)).thenReturn(Optional.empty());
+            when(entityFacade.getStudy(studyId)).thenThrow(new MosException(StudyErrorCode.STUDY_NOT_FOUND));
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
@@ -83,8 +87,8 @@ class StudyCurriculumServiceTest {
             });
 
             assertEquals(StudyErrorCode.STUDY_NOT_FOUND, exception.getErrorCode());
-            verify(studyRepository).findById(studyId);
-            verify(userRepository, never()).findById(anyLong());
+            verify(entityFacade, never()).getUser(userId);
+            verify(entityFacade).getStudy(studyId);
             verify(studyMemberRepository, never()).save(any(StudyMember.class));
         }
 
@@ -96,8 +100,8 @@ class StudyCurriculumServiceTest {
             Long userId = 1L;
             Study mockStudy = mock(Study.class);
 
-            when(studyRepository.findById(studyId)).thenReturn(Optional.of(mockStudy));
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(entityFacade.getStudy(studyId)).thenReturn(mockStudy);
+            when(entityFacade.getUser(userId)).thenThrow(new MosException(UserErrorCode.USER_NOT_FOUND));
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
@@ -105,8 +109,8 @@ class StudyCurriculumServiceTest {
             });
 
             assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-            verify(studyRepository).findById(studyId);
-            verify(userRepository).findById(userId);
+            verify(entityFacade).getStudy(studyId);
+            verify(entityFacade).getUser(userId);
             verify(studyMemberRepository, never()).save(any(StudyMember.class));
         }
     }

--- a/src/test/java/com/mos/backend/studymembers/application/StudyMemberServiceTest.java
+++ b/src/test/java/com/mos/backend/studymembers/application/StudyMemberServiceTest.java
@@ -1,11 +1,14 @@
 package com.mos.backend.studymembers.application;
 
 import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
 import com.mos.backend.studies.entity.Study;
 import com.mos.backend.studies.entity.exception.StudyErrorCode;
 import com.mos.backend.studies.infrastructure.StudyRepository;
 import com.mos.backend.studymembers.entity.StudyMember;
+import com.mos.backend.studymembers.entity.exception.StudyMemberErrorCode;
 import com.mos.backend.studymembers.infrastructure.StudyMemberRepository;
+import com.mos.backend.studyparticipations.entity.StudyApplication;
 import com.mos.backend.users.entity.User;
 import com.mos.backend.users.entity.exception.UserErrorCode;
 import com.mos.backend.users.infrastructure.respository.UserRepository;
@@ -30,19 +33,18 @@ import static org.mockito.Mockito.*;
 class StudyMemberServiceTest {
     @Mock
     private StudyRepository studyRepository;
-
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private StudyMemberRepository studyMemberRepository;
-
+    @Mock
+    private EntityFacade entityFacade;
     @InjectMocks
     private StudyMemberService studyMemberService;
 
     @Nested
     @DisplayName("스터디 멤버 생성 성공 시나리오")
-    class SuccessScenarios {
+    class CreateSuccessScenarios {
         @Test
         @DisplayName("정상적인 스터디 멤버 생성")
         void createStudyMember_Success() {
@@ -52,23 +54,22 @@ class StudyMemberServiceTest {
             Study mockStudy = mock(Study.class);
             User mockUser = mock(User.class);
 
-
-            when(studyRepository.findById(studyId)).thenReturn(Optional.of(mockStudy));
-            when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+            when(entityFacade.getStudy(studyId)).thenReturn(mockStudy);
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
 
             // When
             studyMemberService.create(studyId, userId);
 
             // Then
-            verify(studyRepository).findById(studyId);
-            verify(userRepository).findById(userId);
+            verify(entityFacade).getStudy(studyId);
+            verify(entityFacade).getUser(userId);
             verify(studyMemberRepository).save(any(StudyMember.class));
         }
     }
 
     @Nested
     @DisplayName("스터디 멤버 생성 실패 시나리오")
-    class FailureScenarios {
+    class CreateFailureScenarios {
         @Test
         @DisplayName("스터디가 존재하지 않을 때 MosException 발생")
         void createStudyMember_StudyNotFound() {
@@ -76,7 +77,7 @@ class StudyMemberServiceTest {
             Long studyId = 1L;
             Long userId = 1L;
 
-            when(studyRepository.findById(studyId)).thenReturn(Optional.empty());
+            when(entityFacade.getStudy(studyId)).thenThrow(new MosException(StudyErrorCode.STUDY_NOT_FOUND));
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
@@ -84,8 +85,8 @@ class StudyMemberServiceTest {
             });
 
             assertEquals(StudyErrorCode.STUDY_NOT_FOUND, exception.getErrorCode());
-            verify(studyRepository).findById(studyId);
-            verify(userRepository, never()).findById(anyLong());
+            verify(entityFacade).getStudy(studyId);
+            verify(entityFacade, never()).getUser(anyLong());
             verify(studyMemberRepository, never()).save(any(StudyMember.class));
         }
 
@@ -97,8 +98,8 @@ class StudyMemberServiceTest {
             Long userId = 1L;
             Study mockStudy = mock(Study.class);
 
-            when(studyRepository.findById(studyId)).thenReturn(Optional.of(mockStudy));
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(entityFacade.getStudy(studyId)).thenReturn(mockStudy);
+            when(entityFacade.getUser(userId)).thenThrow(new MosException(UserErrorCode.USER_NOT_FOUND));
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
@@ -106,8 +107,8 @@ class StudyMemberServiceTest {
             });
 
             assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-            verify(studyRepository).findById(studyId);
-            verify(userRepository).findById(userId);
+            verify(entityFacade).getStudy(studyId);
+            verify(entityFacade).getUser(userId);
             verify(studyMemberRepository, never()).save(any(StudyMember.class));
         }
     }

--- a/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
+++ b/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
@@ -1,0 +1,126 @@
+package com.mos.backend.studyparticipations.application;
+
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studies.entity.exception.StudyErrorCode;
+import com.mos.backend.studymembers.entity.StudyMember;
+import com.mos.backend.studymembers.entity.exception.StudyMemberErrorCode;
+import com.mos.backend.studymembers.infrastructure.StudyMemberRepository;
+import com.mos.backend.studyparticipations.entity.StudyApplication;
+import com.mos.backend.users.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StudyApplicationService 테스트")
+public class StudyApplicationServiceTest {
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+    @Mock
+    private EntityFacade entityFacade;
+    @InjectMocks
+    private StudyApplicationService studyApplicationService;
+
+
+    @Nested
+    @DisplayName("스터디 멤버 승인 성공 시나리오")
+    class ApproveSuccessScenarios {
+        @Test
+        @DisplayName("스터디 멤버 승인")
+        void approveStudyMember_Success() {
+            // Given
+            Long userId = 1L;
+            Long studyApplicationId = 1L;
+            User mockUser = mock(User.class);
+            Study mockStudy = mock(Study.class);
+            StudyApplication mockStudyApplication = mock(StudyApplication.class);
+
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
+            when(entityFacade.getStudyApplication(studyApplicationId)).thenReturn(mockStudyApplication);
+            when(mockStudyApplication.getStudy()).thenReturn(mockStudy);
+            when(studyMemberRepository.countByStudy(mockStudy)).thenReturn(1L);
+            when(mockStudy.getMaxParticipantsCount()).thenReturn(5);
+
+            // When
+            studyApplicationService.approveStudyMember(userId, studyApplicationId);
+
+            // Then
+            verify(entityFacade).getUser(userId);
+            verify(entityFacade).getStudyApplication(studyApplicationId);
+            verify(mockStudyApplication).approve();
+            verify(studyMemberRepository).save(any(StudyMember.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디 멤버 승인 실패 시나리오")
+    class ApproveFailureScenarios {
+        @Test
+        @DisplayName("스터디가 존재하지 않을 때 MosException 발생")
+        void approveStudyMember_StudyNotFound() {
+            // Given
+            Long userId = 1L;
+            Long studyApplicationId = 1L;
+            User mockUser = mock(User.class);
+            Study mockStudy = mock(Study.class);
+            StudyApplication mockStudyApplication = mock(StudyApplication.class);
+
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
+            when(entityFacade.getStudyApplication(studyApplicationId)).thenReturn(mockStudyApplication);
+            when(mockStudyApplication.getStudy()).thenReturn(mockStudy);
+            when(studyMemberRepository.countByStudy(mockStudy)).thenReturn(0L);
+
+            // When & Then
+            MosException exception = assertThrows(MosException.class, () -> {
+                studyApplicationService.approveStudyMember(userId, studyApplicationId);
+            });
+
+            assertEquals(StudyErrorCode.STUDY_NOT_FOUND, exception.getErrorCode());
+
+            verify(entityFacade).getUser(userId);
+            verify(entityFacade).getStudyApplication(studyApplicationId);
+            verify(mockStudyApplication, never()).approve();
+            verify(studyMemberRepository, never()).save(any(StudyMember.class));
+        }
+
+        @Test
+        @DisplayName("스터디 멤버가 가득 찼을 때 MosException 발생")
+        void approveStudyMember_StudyMemberFull() {
+            // Given
+            Long userId = 1L;
+            Long studyApplicationId = 1L;
+            User mockUser = mock(User.class);
+            Study mockStudy = mock(Study.class);
+            StudyApplication mockStudyApplication = mock(StudyApplication.class);
+
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
+            when(entityFacade.getStudyApplication(studyApplicationId)).thenReturn(mockStudyApplication);
+            when(mockStudyApplication.getStudy()).thenReturn(mockStudy);
+            when(studyMemberRepository.countByStudy(mockStudy)).thenReturn(4L);
+            when(mockStudy.getMaxParticipantsCount()).thenReturn(4);
+
+            // When & Then
+            MosException exception = assertThrows(MosException.class, () -> {
+                studyApplicationService.approveStudyMember(userId, studyApplicationId);
+            });
+
+            assertEquals(StudyMemberErrorCode.STUDY_MEMBER_FULL, exception.getErrorCode());
+
+            verify(entityFacade).getUser(userId);
+            verify(entityFacade).getStudyApplication(studyApplicationId);
+            verify(mockStudyApplication, never()).approve();
+            verify(studyMemberRepository, never()).save(any(StudyMember.class));
+        }
+    }
+}

--- a/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
+++ b/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
@@ -123,4 +123,29 @@ public class StudyApplicationServiceTest {
             verify(studyMemberRepository, never()).save(any(StudyMember.class));
         }
     }
+
+    @Nested
+    @DisplayName("스터디 신청 거절 성공 시나리오")
+    class RejectSuccessScenarios {
+        @Test
+        @DisplayName("스터디 신청 거절")
+        void rejectStudyMember_Success() {
+            // Given
+            Long userId = 1L;
+            Long studyApplicationId = 1L;
+            User mockUser = mock(User.class);
+            StudyApplication mockStudyApplication = mock(StudyApplication.class);
+
+            when(entityFacade.getUser(userId)).thenReturn(mockUser);
+            when(entityFacade.getStudyApplication(studyApplicationId)).thenReturn(mockStudyApplication);
+
+            // When
+            studyApplicationService.rejectStudyApplication(userId, studyApplicationId);
+
+            // Then
+            verify(entityFacade).getUser(userId);
+            verify(entityFacade).getStudyApplication(studyApplicationId);
+            verify(mockStudyApplication).reject();
+        }
+    }
 }

--- a/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
+++ b/src/test/java/com/mos/backend/studyparticipations/application/StudyApplicationServiceTest.java
@@ -34,10 +34,10 @@ public class StudyApplicationServiceTest {
 
 
     @Nested
-    @DisplayName("스터디 멤버 승인 성공 시나리오")
+    @DisplayName("스터디 신청 승인 성공 시나리오")
     class ApproveSuccessScenarios {
         @Test
-        @DisplayName("스터디 멤버 승인")
+        @DisplayName("스터디 신청 승인")
         void approveStudyMember_Success() {
             // Given
             Long userId = 1L;
@@ -53,7 +53,7 @@ public class StudyApplicationServiceTest {
             when(mockStudy.getMaxParticipantsCount()).thenReturn(5);
 
             // When
-            studyApplicationService.approveStudyMember(userId, studyApplicationId);
+            studyApplicationService.approveStudyApplication(userId, studyApplicationId);
 
             // Then
             verify(entityFacade).getUser(userId);
@@ -64,7 +64,7 @@ public class StudyApplicationServiceTest {
     }
 
     @Nested
-    @DisplayName("스터디 멤버 승인 실패 시나리오")
+    @DisplayName("스터디 신청 승인 실패 시나리오")
     class ApproveFailureScenarios {
         @Test
         @DisplayName("스터디가 존재하지 않을 때 MosException 발생")
@@ -83,7 +83,7 @@ public class StudyApplicationServiceTest {
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
-                studyApplicationService.approveStudyMember(userId, studyApplicationId);
+                studyApplicationService.approveStudyApplication(userId, studyApplicationId);
             });
 
             assertEquals(StudyErrorCode.STUDY_NOT_FOUND, exception.getErrorCode());
@@ -112,7 +112,7 @@ public class StudyApplicationServiceTest {
 
             // When & Then
             MosException exception = assertThrows(MosException.class, () -> {
-                studyApplicationService.approveStudyMember(userId, studyApplicationId);
+                studyApplicationService.approveStudyApplication(userId, studyApplicationId);
             });
 
             assertEquals(StudyMemberErrorCode.STUDY_MEMBER_FULL, exception.getErrorCode());

--- a/src/test/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationControllerTest.java
+++ b/src/test/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationControllerTest.java
@@ -1,0 +1,52 @@
+package com.mos.backend.studyparticipations.presentation.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mos.backend.common.jwt.TokenUtil;
+import com.mos.backend.securityuser.WithMockCustomUser;
+import com.mos.backend.studyparticipations.application.StudyApplicationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StudyApplicationController.class)
+@AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+@AutoConfigureMockMvc(addFilters = false)
+@WithMockCustomUser(userId = 1L)
+class StudyApplicationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StudyApplicationService studyApplicationService;
+    @MockitoBean
+    private TokenUtil tokenUtil;
+
+    @Test
+    @DisplayName("스터디 신청 승인 성공 문서화")
+    void approveStudyApplication_Success_Documentation() throws Exception {
+        mockMvc.perform(
+                        put("/study-applications/1/approval")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("study-applications-approve-success",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationControllerTest.java
+++ b/src/test/java/com/mos/backend/studyparticipations/presentation/controller/api/StudyApplicationControllerTest.java
@@ -49,4 +49,19 @@ class StudyApplicationControllerTest {
                         )
                 );
     }
+
+    @Test
+    @DisplayName("스터디 신청 거절 성공 문서화")
+    void rejectStudyApplication_Success_Documentation() throws Exception {
+        mockMvc.perform(
+                        put("/study-applications/1/rejection")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(document("study-applications-reject-success",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint())
+                        )
+                );
+    }
 }


### PR DESCRIPTION
## ⭐ Issue Number
> #48

<br>

## 📌 Tasks
1. StudyService에 EntityFacade 적용
2. StudyService 수정으로 인한 테스트 실패 해결
3. StudyQuestion의 questId -> questionNum 으로 변경
4. 스터디 신청 승인 api 구현
5. 스터디 신청 거절 api 구현

<br>

## ETC
스터디의 신청자 목록 조회 api를 구현하려 했으나, 엔티티 이름도 헷갈리고 연관관계도 고쳐야될 부분이 존재해서 이 부분 개선 후 진행하겠습니다
