### PR TITLE
Feat/mystudy #175

### DIFF
--- a/src/main/java/com/mos/backend/studies/application/StudyService.java
+++ b/src/main/java/com/mos/backend/studies/application/StudyService.java
@@ -17,6 +17,10 @@ import com.mos.backend.studies.entity.exception.StudyErrorCode;
 import com.mos.backend.studies.infrastructure.StudyRepository;
 import com.mos.backend.studies.presentation.requestdto.StudyCreateRequestDto;
 import com.mos.backend.studymembers.application.StudyMemberService;
+import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
+import com.mos.backend.users.entity.User;
+import com.mos.backend.users.entity.UserRole;
+import com.mos.backend.users.entity.exception.UserErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -138,6 +142,19 @@ public class StudyService {
     public StudyCategoriesResponseDto getStudyCategories() {
         List<String> list = Arrays.stream(Category.values()).map(Category::getDescription).toList();
         return new StudyCategoriesResponseDto(list);
+    }
+
+    /**
+     * 유저의 참여 중인 스터디 목록 조회
+     */
+    public List<UserStudiesResponseDto> readUserStudies(Long userId, String progressStatus, String participationStatus, Long currentUserId) {
+        User user = entityFacade.getUser(userId);
+        User currentUser = entityFacade.getUser(currentUserId);
+
+        if (UserRole.USER.equals(currentUser.getRole()) && !user.equals(currentUser)) {
+            throw new MosException(UserErrorCode.USER_STUDY_ACCESS_FORBIDDEN);
+        }
+        return studyRepository.readUserStudies(user, progressStatus, participationStatus);
     }
 
     private Study findStudyById(long studyId) {

--- a/src/main/java/com/mos/backend/studies/infrastructure/StudyRepository.java
+++ b/src/main/java/com/mos/backend/studies/infrastructure/StudyRepository.java
@@ -2,9 +2,12 @@ package com.mos.backend.studies.infrastructure;
 
 import com.mos.backend.studies.application.responsedto.StudiesResponseDto;
 import com.mos.backend.studies.entity.Study;
+import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
+import com.mos.backend.users.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StudyRepository {
@@ -18,4 +21,6 @@ public interface StudyRepository {
     long count();
 
     void delete(Study study);
+
+    List<UserStudiesResponseDto> readUserStudies(User user, String progressStatusCond, String participationStatusCond);
 }

--- a/src/main/java/com/mos/backend/studies/infrastructure/StudyRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/studies/infrastructure/StudyRepositoryImpl.java
@@ -2,11 +2,14 @@ package com.mos.backend.studies.infrastructure;
 
 import com.mos.backend.studies.application.responsedto.StudiesResponseDto;
 import com.mos.backend.studies.entity.Study;
+import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
+import com.mos.backend.users.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -45,5 +48,10 @@ public class StudyRepositoryImpl implements StudyRepository{
     @Override
     public void delete(Study study) {
         studyJpaRepository.delete(study);
+    }
+
+    @Override
+    public List<UserStudiesResponseDto> readUserStudies(User user, String progressStatusCond, String participationStatusCond) {
+        return studyQueryDSLRepository.readUserStudies(user, progressStatusCond, participationStatusCond);
     }
 }

--- a/src/main/java/com/mos/backend/studymembers/entity/ParticipationStatus.java
+++ b/src/main/java/com/mos/backend/studymembers/entity/ParticipationStatus.java
@@ -1,7 +1,11 @@
 package com.mos.backend.studymembers.entity;
 
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.studymembers.entity.exception.StudyMemberErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -12,4 +16,10 @@ public enum ParticipationStatus {
     WITHDRAWN("탈퇴");
 
     private final String description;
+
+    public static ParticipationStatus fromDescription(String description) {
+        return Arrays.stream(ParticipationStatus.values())
+                .filter(p -> p.description.equals(description))
+                .findFirst().orElseThrow(()-> new MosException(StudyMemberErrorCode.INVALID_PARTICIPATION_STATUS));
+    }
 }

--- a/src/main/java/com/mos/backend/studymembers/entity/StudyMemberRoleType.java
+++ b/src/main/java/com/mos/backend/studymembers/entity/StudyMemberRoleType.java
@@ -1,7 +1,11 @@
 package com.mos.backend.studymembers.entity;
 
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.studymembers.entity.exception.StudyMemberErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 @AllArgsConstructor
@@ -9,4 +13,10 @@ public enum StudyMemberRoleType {
     LEADER("스터디장"), MEMBER("스터디원");
 
     private final String description;
+
+    public static StudyMemberRoleType fromDescription(String description) {
+        return Arrays.stream(StudyMemberRoleType.values())
+                .filter(r -> r.description.equals(description))
+                .findFirst().orElseThrow(()-> new MosException(StudyMemberErrorCode.INVALID_STUDY_MEMBER_ROLE_TYPE));
+    }
 }

--- a/src/main/java/com/mos/backend/studymembers/entity/exception/StudyMemberErrorCode.java
+++ b/src/main/java/com/mos/backend/studymembers/entity/exception/StudyMemberErrorCode.java
@@ -14,7 +14,8 @@ public enum StudyMemberErrorCode implements ErrorCode {
     STUDY_LEADER_ALREADY_EXIST(HttpStatus.CONFLICT, "study-member.leader-already-exist"),
     STUDY_LEADER_WITHDRAW_FORBIDDEN(HttpStatus.FORBIDDEN, "study-member.leader-withdraw-forbidden"),
     INVALID_STUDY_MEMBER_ROLE_TYPE(HttpStatus.BAD_REQUEST, "study-member.invalid-role-type"),
-    ONLY_LEADER_CAN_DELEGATE(HttpStatus.FORBIDDEN, "study-member.only-leader-can-delegate");
+    ONLY_LEADER_CAN_DELEGATE(HttpStatus.FORBIDDEN, "study-member.only-leader-can-delegate"),
+    INVALID_PARTICIPATION_STATUS(HttpStatus.BAD_REQUEST, "study-member.invalid-participation-status");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mos/backend/users/application/responsedto/UserStudiesResponseDto.java
+++ b/src/main/java/com/mos/backend/users/application/responsedto/UserStudiesResponseDto.java
@@ -1,0 +1,41 @@
+package com.mos.backend.users.application.responsedto;
+
+import com.mos.backend.studies.entity.*;
+import com.mos.backend.studymembers.entity.ParticipationStatus;
+import com.mos.backend.studymembers.entity.StudyMemberRoleType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class UserStudiesResponseDto {
+    private Long id;
+    private String title;
+    private String category;
+    private String meetingType;
+    private String progressStatus;
+    private String participationStatus;
+    private Long currentStudyMembers;
+    private Integer maxStudyMembers;
+    private String schedule;
+    private String studyMemberRole;
+    private List<String> tags;
+
+    public UserStudiesResponseDto(Long studyId, String title, Category category, MeetingType meetingType, ProgressStatus progressStatus,
+                                  ParticipationStatus participationStatus, Long currentStudyMembers, Integer maxStudyMembers, String schedule, StudyTag tags, StudyMemberRoleType studyMemberRoleType) {
+        this.id = studyId;
+        this.title = title;
+        this.category = category.getDescription();
+        this.meetingType = meetingType.getDescription();
+        this.progressStatus = progressStatus.getDescription();
+        this.currentStudyMembers = currentStudyMembers;
+        this.maxStudyMembers = maxStudyMembers;
+        this.schedule = schedule;
+        this.participationStatus = participationStatus.getDescription();
+        this.studyMemberRole = studyMemberRoleType.getDescription();
+        this.tags = tags.toList();
+    }
+}

--- a/src/main/java/com/mos/backend/users/entity/exception/UserErrorCode.java
+++ b/src/main/java/com/mos/backend/users/entity/exception/UserErrorCode.java
@@ -15,7 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "auth.user.unauthorized"),
     MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "auth.user.missing-access-token"),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "auth.user.invalid-access-token"),
-    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "auth.user.expired-access-token");
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "auth.user.expired-access-token"),
+    USER_STUDY_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "user.study-access-forbidden");
 
     private final HttpStatus httpStatus;
     private final String messageKey;

--- a/src/main/java/com/mos/backend/users/presentation/controller/api/UserController.java
+++ b/src/main/java/com/mos/backend/users/presentation/controller/api/UserController.java
@@ -1,7 +1,11 @@
 package com.mos.backend.users.presentation.controller.api;
 
+import com.mos.backend.studies.application.StudyService;
+import com.mos.backend.studies.entity.ProgressStatus;
+import com.mos.backend.studymembers.entity.ParticipationStatus;
 import com.mos.backend.users.application.UserService;
 import com.mos.backend.users.application.responsedto.UserDetailRes;
+import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
 import com.mos.backend.users.presentation.requestdto.UserUpdateReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +13,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/users")
 @RestController
 public class UserController {
     private final UserService userService;
+    private final StudyService studyService;
 
     @PatchMapping
     public ResponseEntity<Void> update(@AuthenticationPrincipal Long userId, @Valid @RequestBody UserUpdateReq req) {
@@ -24,5 +31,14 @@ public class UserController {
     @GetMapping
     public ResponseEntity<UserDetailRes> getDetail(@AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok(userService.getDetail(userId));
+    }
+
+    @GetMapping("/{userId}/studies")
+    public List<UserStudiesResponseDto> readUserStudies(
+            @PathVariable Long userId,
+            @RequestParam(required = false) String progressStatus,
+            @RequestParam(required = false) String participationStatus,
+            @AuthenticationPrincipal Long currentUserId) {
+        return studyService.readUserStudies(userId, progressStatus, participationStatus, currentUserId);
     }
 }

--- a/src/main/resources/messages/messages-error.properties
+++ b/src/main/resources/messages/messages-error.properties
@@ -8,14 +8,14 @@ auth.user.expired-access-token=액세스 토큰이 만료되었습니다.
 user.study-access-forbidden=해당 유저의 스터디 참여 목록을 조회할 권한이 없습니다.
 
 # Study
-study.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514\uC785\uB2C8\uB2E4.
-study.invalid-recruitment-dates=\uBAA8\uC9D1 \uB9C8\uAC10 \uB0A0\uC9DC\uB294 \uC2DC\uC791 \uB0A0\uC9DC\uBCF4\uB2E4 \uCEE4\uC57C \uD569\uB2C8\uB2E4.
-study.invalid-recruitment-status=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 recruitmentStatus \uC785\uB2C8\uB2E4.
-study.invalid-progress-status=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 progressStatus \uC785\uB2C8\uB2E4.
-study.internal-server-error=\uC11C\uBC84\uC5D0 \uC7A5\uC560\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4.
-study.unrelated-study=\uC5F0\uAD00\uB418\uC9C0 \uC54A\uC740 \uC2A4\uD130\uB514\uC5D0 \uB300\uD55C \uC694\uCCAD\uC785\uB2C8\uB2E4.
-study.not-in-recruitment-period=\uC2A4\uD130\uB514 \uBAA8\uC9D1 \uAE30\uAC04\uC774 \uC544\uB2D9\uB2C8\uB2E4.
-study.recruitment-closed=\uC2A4\uD130\uB514 \uBAA8\uC9D1\uC774 \uB9C8\uAC10\uB418\uC5C8\uC2B5\uB2C8\uB2E4.
+study.not-found=존재하지 않는 스터디입니다.
+study.invalid-recruitment-dates=모집 마감 날짜는 시작 날짜보다 커야 합니다.
+study.invalid-recruitment-status=올바르지 않은 recruitmentStatus 입니다.
+study.invalid-progress-status=올바르지 않은 progressStatus 입니다.
+study.internal-server-error=서버에 장애가 발생했습니다.
+study.unrelated-study=연관되지 않은 스터디에 대한 요청입니다.
+study.not-in-recruitment-period=스터디 모집 기간이 아닙니다.
+study.recruitment-closed=스터디 모집이 마감되었습니다.
 
 ## Study - Category
 study.category.not-found=존재하지 않는 카테고리입니다.
@@ -29,17 +29,14 @@ study-question.invalid-short-answer=주관식에는 선택지를 둘 수 없습�
 study-question.invalid-question-num=유효하지 않은 questionNum 입니다.
 study-question.mismatch=질문이 요청한 스터디와 일치하지 않습니다.
 
-
-
 # Study - Join
-study-join.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uAC00\uC785 \uC694\uCCAD\uC785\uB2C8\uB2E4.
-study-join.mismatch=\uC2A4\uD130\uB514 \uAC00\uC785\uC774 \uC694\uCCAD\uD55C \uC2A4\uD130\uB514\uC640 \uC77C\uCE58\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
-study-join.not-pending=\uAC00\uC785 \uC694\uCCAD\uC774 \uB300\uAE30 \uC0C1\uD0DC\uAC00 \uC544\uB2D9\uB2C8\uB2E4.
-study-join.status.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uAC00\uC785 \uC0C1\uD0DC\uC785\uB2C8\uB2E4.
-study-join.invalid-answer-option=\uAC1D\uAD00\uC2DD \uC120\uD0DD\uC9C0\uB97C \uC798\uBABB \uC785\uB825\uD588\uC2B5\uB2C8\uB2E4.
-study-join.missing-required-questions=\uD544\uC218 \uC9C8\uBB38\uC5D0 \uB300\uD55C \uB2F5\uBCC0\uC774 \uB204\uB77D\uB418\uC5C8\uC2B5\uB2C8\uB2E4.
-study-join.conflict=\uC774\uBBF8 \uC874\uC7AC\uD558\uB294 \uAC00\uC785 \uC694\uCCAD\uC785\uB2C8\uB2E4.
-
+study-join.not-found=존재하지 않는 가입 요청입니다.
+study-join.mismatch=스터디 가입이 요청한 스터디와 일치하지 않습니다.
+study-join.not-pending=가입 요청이 대기 상태가 아닙니다.
+study-join.status.not-found=존재하지 않는 가입 상태입니다.
+study-join.invalid-answer-option=객관식 선택지를 잘못 입력했습니다.
+study-join.missing-required-questions=필수 질문에 대한 답변이 누락되었습니다.
+study-join.conflict=이미 존재하는 가입 요청입니다.
 
 # Study - Member
 study-member.not-found=존재하지 않는 스터디 멤버입니다.

--- a/src/main/resources/messages/messages-error.properties
+++ b/src/main/resources/messages/messages-error.properties
@@ -1,10 +1,11 @@
 # User
-auth.user.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC720\uC800 \uC544\uC774\uB514\uC785\uB2C8\uB2E4.
-auth.user.forbidden=\uC720\uC800\uC5D0\uAC8C \uAD8C\uD55C\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.
-auth.user.unauthorized=\uC720\uC800\uAC00 \uC778\uC99D\uB418\uC9C0 \uC54A\uC558\uC2B5\uB2C8\uB2E4.
-auth.user.missing-access-token=\uC561\uC138\uC2A4 \uD1A0\uD070\uC774 \uC874\uC7AC\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
-auth.user.invalid-access-token=\uC561\uC138\uC2A4 \uD1A0\uD070\uC774 \uC62C\uBC14\uB974\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
-auth.user.expired-access-token=\uC561\uC138\uC2A4 \uD1A0\uD070\uC774 \uB9CC\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4.
+auth.user.not-found=존재하지 않는 유저 아이디입니다.
+auth.user.forbidden=유저에게 권한이 없습니다.
+auth.user.unauthorized=유저가 인증되지 않았습니다.
+auth.user.missing-access-token=액세스 토큰이 존재하지 않습니다.
+auth.user.invalid-access-token=액세스 토큰이 올바르지 않습니다.
+auth.user.expired-access-token=액세스 토큰이 만료되었습니다.
+user.study-access-forbidden=해당 유저의 스터디 참여 목록을 조회할 권한이 없습니다.
 
 # Study
 study.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514\uC785\uB2C8\uB2E4.
@@ -17,16 +18,16 @@ study.not-in-recruitment-period=\uC2A4\uD130\uB514 \uBAA8\uC9D1 \uAE30\uAC04\uC7
 study.recruitment-closed=\uC2A4\uD130\uB514 \uBAA8\uC9D1\uC774 \uB9C8\uAC10\uB418\uC5C8\uC2B5\uB2C8\uB2E4.
 
 ## Study - Category
-study.category.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uCE74\uD14C\uACE0\uB9AC\uC785\uB2C8\uB2E4.
-study.meeting-type.invalid=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 meetingType \uC785\uB2C8\uB2E4.
+study.category.not-found=존재하지 않는 카테고리입니다.
+study.meeting-type.invalid=올바르지 않은 meetingType 입니다.
 
 # Study - Question
-study-question.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC9C8\uBB38\uC785\uB2C8\uB2E4.
-study-question.invalid-question-type=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 \uC9C8\uBB38 \uC720\uD615\uC785\uB2C8\uB2E4.
-study-question.invalid-multiple-choice-options=\uAC1D\uAD00\uC2DD\uC758 \uC120\uD0DD\uC9C0\uB294 \uB450 \uAC1C \uC774\uC0C1\uC774\uC5B4\uC57C \uD569\uB2C8\uB2E4.
-study-question.invalid-short-answer=\uC8FC\uAD00\uC2DD\uC5D0\uB294 \uC120\uD0DD\uC9C0\uB97C \uB458 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
-study-question.invalid-question-num=\uC720\uD6A8\uD558\uC9C0 \uC54A\uC740 questionNum \uC785\uB2C8\uB2E4.
-study-question.mismatch=\uC9C8\uBB38\uC774 \uC694\uCCAD\uD55C \uC2A4\uD130\uB514\uC640 \uC77C\uCE58\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
+study-question.not-found=존재하지 않는 질문입니다.
+study-question.invalid-question-type=올바르지 않은 질문 유형입니다.
+study-question.invalid-multiple-choice-options=객관식의 선택지는 두 개 이상이어야 합니다.
+study-question.invalid-short-answer=주관식에는 선택지를 둘 수 없습니다.
+study-question.invalid-question-num=유효하지 않은 questionNum 입니다.
+study-question.mismatch=질문이 요청한 스터디와 일치하지 않습니다.
 
 
 
@@ -41,65 +42,66 @@ study-join.conflict=\uC774\uBBF8 \uC874\uC7AC\uD558\uB294 \uAC00\uC785 \uC694\uC
 
 
 # Study - Member
-study-member.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514 \uBA64\uBC84\uC785\uB2C8\uB2E4.
-study-member.full=\uC2A4\uD130\uB514 \uC778\uC6D0\uC774 \uAC00\uB4DD \uCC3C\uC2B5\uB2C8\uB2E4.
-study-member.leader-already-exist=\uC2A4\uD130\uB514 \uB9AC\uB354\uAC00 \uC774\uBBF8 \uC874\uC7AC\uD569\uB2C8\uB2E4.
-study-member.leader-withdraw-forbidden=\uB9AC\uB354\uB294 \uD0C8\uD1F4\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
-study-member.invalid-role-type=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 \uC5ED\uD560\uBA85\uC785\uB2C8\uB2E4.
-study-member.only-leader-can-delegate=\uB9AC\uB354\uB9CC \uB2E4\uB978 \uBA64\uBC84\uC5D0\uAC8C \uB9AC\uB354\uB97C \uC704\uC784\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.
+study-member.not-found=존재하지 않는 스터디 멤버입니다.
+study-member.full=스터디 인원이 가득 찼습니다.
+study-member.leader-already-exist=스터디 리더가 이미 존재합니다.
+study-member.leader-withdraw-forbidden=리더는 탈퇴할 수 없습니다.
+study-member.invalid-role-type=올바르지 않은 역할명입니다.
+study-member.only-leader-can-delegate=리더만 다른 멤버에게 리더를 위임할 수 있습니다.
+study-member.invalid-participation-status=올바르지 않은 participationStatus 입니다.
 
 # Study - Benefit
-study-benefit.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 benefit \uC785\uB2C8\uB2E4.
-study-benefit.invalid-benefit-num=\uC720\uD6A8\uD558\uC9C0 \uC54A\uC740 benefitNum \uC785\uB2C8\uB2E4.
+study-benefit.not-found=존재하지 않는 benefit 입니다.
+study-benefit.invalid-benefit-num=유효하지 않은 benefitNum 입니다.
 
 # Study - Curriculum
-study-curriculum.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uCEE4\uB9AC\uD058\uB7FC\uC785\uB2C8\uB2E4.
-study-curriculum.invalid-section-id=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 sectionId \uC785\uB2C8\uB2E4.
+study-curriculum.not-found=존재하지 않는 커리큘럼입니다.
+study-curriculum.invalid-section-id=올바르지 않은 sectionId 입니다.
 
 # Study - Schedule
-study-schedule.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514 \uC77C\uC815\uC785\uB2C8\uB2E4.
-study-schedule.completed=\uC774\uBBF8 \uC644\uB8CC\uB41C \uC2A4\uD130\uB514 \uC77C\uC815\uC785\uB2C8\uB2E4.
+study-schedule.not-found=존재하지 않는 스터디 일정입니다.
+study-schedule.completed=이미 완료된 스터디 일정입니다.
 
 # Attendance
-attendance.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uCD9C\uC11D\uC785\uB2C8\uB2E4.
-attendance.already-exist=\uC774\uBBF8 \uC874\uC7AC\uD558\uB294 \uCD9C\uC11D\uC785\uB2C8\uB2E4.
-attendance.invalid-status=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 \uCD9C\uC11D \uC0C1\uD0DC \uC785\uB2C8\uB2E4.
-attendance.unrelated=\uC5F0\uAD00\uB418\uC9C0 \uC54A\uC740 \uCD9C\uC11D\uC785\uB2C8\uB2E4.
-attendance.not-present-time=\uCD9C\uC11D \uC2DC\uAC04\uC774 \uC544\uB2D9\uB2C8\uB2E4.
-attendance.unmodifiable-status=\uC218\uC815\uD560 \uC218 \uC5C6\uB294 \uCD9C\uC11D \uC0C1\uD0DC\uC785\uB2C8\uB2E4.
+attendance.not-found=존재하지 않는 출석입니다.
+attendance.already-exist=이미 존재하는 출석입니다.
+attendance.invalid-status=올바르지 않은 출석 상태 입니다.
+attendance.unrelated=연관되지 않은 출석입니다.
+attendance.not-present-time=출석 시간이 아닙니다.
+attendance.unmodifiable-status=수정할 수 없는 출석 상태입니다.
 
 # Study - Rule
-study-rule.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514 \uB8F0\uC785\uB2C8\uB2E4.
-study-rule.invalid-rule-num=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 ruleNum \uC785\uB2C8\uB2E4.
+study-rule.not-found=존재하지 않는 스터디 룰입니다.
+study-rule.invalid-rule-num=올바르지 않은 ruleNum 입니다.
 
 # Study - Requirement
-study-requirement.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC694\uAD6C\uC0AC\uD56D\uC785\uB2C8\uB2E4.
-study-requirement.invalid-requirement-num=\uC62C\uBC14\uB974\uC9C0 \uC54A\uC740 requirementNum \uC785\uB2C8\uB2E4.
+study-requirement.not-found=존재하지 않는 요구사항입니다.
+study-requirement.invalid-requirement-num=올바르지 않은 requirementNum 입니다.
 
 # Study - Material
-study-material.file-size-exceeded=\uAC1C\uBCC4 \uD30C\uC77C \uD06C\uAE30\uB294 1GB\uB97C \uCD08\uACFC\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
-study-material.total-study-size-exceeded=\uC2A4\uD130\uB514\uC758 \uCD1D \uD30C\uC77C \uC800\uC7A5 \uC6A9\uB7C9(10GB)\uC744 \uCD08\uACFC\uD588\uC2B5\uB2C8\uB2E4.
-study-material.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC5C5\uB85C\uB4DC \uC790\uB8CC\uC785\uB2C8\uB2E4.
-study-material.study-not-match=\uC2A4\uD130\uB514 ID \uC640 \uC790\uB8CC\uAC00 \uC5C5\uB85C\uB4DC\uB41C \uC2A4\uD130\uB514 ID\uAC00 \uC77C\uCE58\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
+study-material.file-size-exceeded=개별 파일 크기는 1GB를 초과할 수 없습니다.
+study-material.total-study-size-exceeded=스터디의 총 파일 저장 용량(10GB)을 초과했습니다.
+study-material.not-found=존재하지 않는 업로드 자료입니다.
+study-material.study-not-match=스터디 ID 와 자료가 업로드된 스터디 ID가 일치하지 않습니다.
 
 #FileUpload
-file-upload.internal-server-error=\uD30C\uC77C \uC5C5\uB85C\uB4DC \uC911 \uC11C\uBC84 \uB0B4\uBD80\uC5D0\uC11C \uC5D0\uB7EC\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4.
-file_delete.internal-server-error=\uD30C\uC77C \uC0AD\uC81C \uC911 \uC11C\uBC84 \uB0B4\uBD80\uC5D0\uC11C \uC5D0\uB7EC\uAC00 \uBC1C\uC0DD\uD588\uC2B5\uB2C8\uB2E4.
+file-upload.internal-server-error=파일 업로드 중 서버 내부에서 에러가 발생했습니다.
+file_delete.internal-server-error=파일 삭제 중 서버 내부에서 에러가 발생했습니다.
 
 # Private Chat Room
-private-chat-room.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 1:1 \uCC44\uD305\uBC29\uC785\uB2C8\uB2E4.
-private-chat-room.conflict=\uC774\uBBF8 \uC874\uC7AC\uD558\uB294 1:1 \uCC44\uD305\uBC29\uC785\uB2C8\uB2E4.
-private-chat-room.forbidden=\uCC44\uD305\uBC29\uC5D0 \uB300\uD55C \uAD8C\uD55C\uC774 \uC874\uC7AC\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
+private-chat-room.not-found=존재하지 않는 1:1 채팅방입니다.
+private-chat-room.conflict=이미 존재하는 1:1 채팅방입니다.
+private-chat-room.forbidden=채팅방에 대한 권한이 존재하지 않습니다.
 
 # Study Chat Room
-study-chat-room.not-found=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC2A4\uD130\uB514 \uCC44\uD305\uBC29\uC785\uB2C8\uB2E4.
-study-chat-room.forbidden=\uCC44\uD305\uBC29\uC5D0 \uB300\uD55C \uAD8C\uD55C\uC774 \uC874\uC7AC\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
+study-chat-room.not-found=존재하지 않는 스터디 채팅방입니다.
+study-chat-room.forbidden=채팅방에 대한 권한이 존재하지 않습니다.
 
 # Private Chat Message
-private-chat-message.deserialization-failed=\uC5ED\uC9C1\uB82C\uD654\uC5D0 \uC2E4\uD328\uD588\uC2B5\uB2C8\uB2E4.
+private-chat-message.deserialization-failed=역직렬화에 실패했습니다.
 
 # Study Chat Message
-study-chat-message.deserialization-failed=\uC5ED\uC9C1\uB82C\uD654\uC5D0 \uC2E4\uD328\uD588\uC2B5\uB2C8\uB2E4.
+study-chat-message.deserialization-failed=역직렬화에 실패했습니다.
 
 # NotificationLog
-notification-log.not-found=\uC54C\uB9BC\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
+notification-log.not-found=알림을 찾을 수 없습니다.

--- a/src/test/java/com/mos/backend/users/presentation/controller/api/UserControllerTest.java
+++ b/src/test/java/com/mos/backend/users/presentation/controller/api/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mos.backend.common.infrastructure.EntityFacade;
 import com.mos.backend.common.jwt.TokenUtil;
 import com.mos.backend.securityuser.WithMockCustomUser;
+import com.mos.backend.studies.application.StudyService;
 import com.mos.backend.studies.entity.Category;
 import com.mos.backend.users.application.UserService;
 import com.mos.backend.users.application.responsedto.UserDetailRes;
@@ -41,6 +42,8 @@ class UserControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
+    @MockitoBean
+    private StudyService studyService;
     @MockitoBean
     private TokenUtil tokenUtil;
     @MockitoBean


### PR DESCRIPTION
## ⭐ Issue Number
> close #175

<br>

## 📌 Tasks
1. 유저가 참여 중인 스터디 조회 api 개발
-  progressStatus와 participationStatus를 조건으로 사용하는 동적 쿼리 작성
- 스터디 목록 조회 요청 검증 : 일반 유저일 때, 본인이 참여 중인 스터디 목록만 조회 가능 

2. 관련 에러 메시지 생성 및 yml 파일 한글 깨진거 수정
- 다른 유저의 스터디 목록 조회 권한 없을 때 발생시키는 에러 추가

3. enum을 description(String)으로 변환하는 메서드 추가
4. TC 작성

<br>
