### PR TITLE
Release/#196

### DIFF
--- a/src/main/java/com/mos/backend/common/auth/StudySecurity.java
+++ b/src/main/java/com/mos/backend/common/auth/StudySecurity.java
@@ -31,7 +31,6 @@ public class StudySecurity {
         Long currentUserId = Long.valueOf(authentication.getName());
 
         User user = entityFacade.getUser(currentUserId);
-        Study study = entityFacade.getStudy(studyId);
 
         if (user.isAdmin()) {
             return true;

--- a/src/main/java/com/mos/backend/studymembers/application/consumer/StudyMemberConsumer.java
+++ b/src/main/java/com/mos/backend/studymembers/application/consumer/StudyMemberConsumer.java
@@ -5,6 +5,7 @@ import com.mos.backend.studies.application.event.StudyCreatedEventPayload;
 import com.mos.backend.studymembers.application.StudyMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -18,6 +19,7 @@ public class StudyMemberConsumer {
     private final StudyMemberService studyMemberService;
 
     @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @Order(1)
     public void handleStudyCreatedEvent(Event<StudyCreatedEventPayload> event) {
         StudyCreatedEventPayload payload = event.getPayload();
         studyMemberService.createStudyLeader(payload.getStudyId(), payload.getUserId());

--- a/src/main/java/com/mos/backend/studynotices/application/StudyNoticeService.java
+++ b/src/main/java/com/mos/backend/studynotices/application/StudyNoticeService.java
@@ -1,0 +1,120 @@
+package com.mos.backend.studynotices.application;
+
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studynotices.application.responsedto.StudyNoticeResponseDto;
+import com.mos.backend.studynotices.entity.StudyNotice;
+import com.mos.backend.studynotices.entity.StudyNoticeErrorCode;
+import com.mos.backend.studynotices.infrastructure.StudyNoticeRepository;
+import com.mos.backend.users.application.UserService;
+import com.mos.backend.users.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyNoticeService {
+
+    private final StudyNoticeRepository studyNoticeRepository;
+    private final UserService userService;
+    private final EntityFacade entityFacade;
+
+    /**
+     * 공지 생성
+     */
+
+    @Transactional
+    @PreAuthorize("@studySecurity.isLeaderOrAdmin(#studyId)")
+    public StudyNoticeResponseDto create(long studyId, long currentUserId, String title, String content, boolean pinned, boolean important) {
+        // 중요 공지로 설정했을 때 중요 공지가 이미 존재하다면 기존 중요 공지 마크 해제
+        if (important) {
+            studyNoticeRepository.findByStudyIdAndImportantIsTrue(studyId).ifPresent(StudyNotice::unmarkAsImportant);
+        }
+
+        Study study = entityFacade.getStudy(studyId);
+        User currentUser = entityFacade.getUser(currentUserId);
+
+        StudyNotice studyNotice = StudyNotice.create(study, currentUser, title, content, pinned, important);
+        StudyNotice savedStudyNotice = studyNoticeRepository.save(studyNotice);
+        return StudyNoticeResponseDto.of(savedStudyNotice, currentUser, currentUser);
+    }
+
+    /**
+     * 공지 수정
+     */
+
+    @Transactional
+    @PreAuthorize("@studySecurity.isLeaderOrAdmin(#studyId)")
+    public StudyNoticeResponseDto update(long studyId, long studyNoticeId, String title, String content, boolean pinned, boolean important) {
+        // 중요 공지로 설정했을 때 중요 공지가 이미 존재하다면 기존 중요 공지 마크 해제
+        if (important) {
+            studyNoticeRepository.findByStudyIdAndImportantIsTrue(studyId).ifPresent(StudyNotice::unmarkAsImportant);
+        }
+
+        StudyNotice studyNotice = findByIdWithUser(studyNoticeId);
+        studyNotice.update(title, content, pinned, important);
+
+        User creator = studyNotice.getUser();
+        User modifier = entityFacade.getUser(studyNotice.getUpdatedBy());
+        return StudyNoticeResponseDto.of(studyNotice, creator, modifier);
+    }
+
+    /**
+     * 공지 삭제
+     */
+
+    @Transactional
+    @PreAuthorize("@studySecurity.isLeaderOrAdmin(#studyId)")
+    public void delete(long studyId, long studyNoticeId) {
+        studyNoticeRepository.deleteById(studyNoticeId);
+    }
+
+    /**
+     * 공지 단 건 조회
+     */
+
+    @PreAuthorize("@studySecurity.isMemberOrAdmin(#studyId)")
+    public StudyNoticeResponseDto readOne(long studyId, long studyNoticeId) {
+        StudyNotice studyNotice = findByIdWithUser(studyNoticeId);
+        User creator = studyNotice.getUser();
+        User modifier = entityFacade.getUser(studyNotice.getUpdatedBy());
+        return StudyNoticeResponseDto.of(studyNotice, creator, modifier);
+    }
+
+    /**
+     * 공지 다 건 조회
+     */
+    @PreAuthorize("@studySecurity.isMemberOrAdmin(#studyId)")
+    public List<StudyNoticeResponseDto> readAll(long studyId) {
+        List<StudyNotice> studyNoticeList = studyNoticeRepository.findAllByStudyId(studyId);
+
+        // 유저 조회 쿼리 최적화를 위해 중복 제거 후 한 번에 조회
+        Set<Long> modifierIdSet = studyNoticeList.stream()
+                .map(StudyNotice::getUpdatedBy)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> modifierMap = userService.findAllById(modifierIdSet).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        return studyNoticeList.stream().map(sn -> {
+            User creator = sn.getUser();
+            User modifier = modifierMap.get(sn.getUpdatedBy());
+            return StudyNoticeResponseDto.of(sn, creator, modifier);
+        }).toList();
+    }
+
+
+    private StudyNotice findByIdWithUser(long studyNoticeId) {
+        return studyNoticeRepository.findById(studyNoticeId)
+                .orElseThrow(() -> new MosException(StudyNoticeErrorCode.STUDY_NOTICE_NOT_EXISTS));
+    }
+}

--- a/src/main/java/com/mos/backend/studynotices/application/responsedto/StudyNoticeResponseDto.java
+++ b/src/main/java/com/mos/backend/studynotices/application/responsedto/StudyNoticeResponseDto.java
@@ -1,0 +1,46 @@
+package com.mos.backend.studynotices.application.responsedto;
+
+import com.mos.backend.studynotices.entity.StudyNotice;
+import com.mos.backend.users.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+public class StudyNoticeResponseDto {
+    private long studyNoticeId;
+    private String title;
+    private String content;
+    private boolean pinned;
+    private boolean important;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private long creatorId;
+    private String creatorNickname;
+    private Long modifierId;
+    private String modifierNickname;
+    private long studyId;
+
+    public static StudyNoticeResponseDto of (StudyNotice studyNotice, User creator, User modifier) {
+        StudyNoticeResponseDto studyNoticeResponseDto = new StudyNoticeResponseDto();
+        studyNoticeResponseDto.studyNoticeId = studyNotice.getId();
+        studyNoticeResponseDto.title = studyNotice.getTitle();
+        studyNoticeResponseDto.content = studyNotice.getContent();
+        studyNoticeResponseDto.pinned = studyNotice.isPinned();
+        studyNoticeResponseDto.important = studyNotice.isImportant();
+        studyNoticeResponseDto.createdAt = studyNotice.getCreatedAt();
+        studyNoticeResponseDto.modifiedAt = studyNotice.getModifiedAt();
+        studyNoticeResponseDto.creatorId = creator.getId();
+        studyNoticeResponseDto.creatorNickname = creator.getNickname();
+        studyNoticeResponseDto.modifierId = studyNotice.getUpdatedBy();
+        if (modifier == null) {
+            studyNoticeResponseDto.modifierNickname = "알 수 없음";
+        } else {
+            studyNoticeResponseDto.modifierNickname = modifier.getNickname();
+        }
+        studyNoticeResponseDto.studyId = studyNotice.getStudy().getId();
+        return studyNoticeResponseDto;
+    }
+}

--- a/src/main/java/com/mos/backend/studynotices/entity/StudyNotice.java
+++ b/src/main/java/com/mos/backend/studynotices/entity/StudyNotice.java
@@ -1,0 +1,66 @@
+package com.mos.backend.studynotices.entity;
+
+import com.mos.backend.common.entity.BaseAuditableEntity;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.users.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_notices")
+public class StudyNotice extends BaseAuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_notice_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean pinned;
+
+    @Column(nullable = false)
+    private boolean important;
+
+    public static StudyNotice create(Study study, User user, String title, String content, boolean pinned, boolean important) {
+        StudyNotice studyNotice = new StudyNotice();
+        studyNotice.study = study;
+        studyNotice.user = user;
+        studyNotice.title = title;
+        studyNotice.content = content;
+        studyNotice.pinned = pinned;
+        studyNotice.important = important;
+        return studyNotice;
+    }
+
+    public void  update(String title, String content, boolean pinned, boolean important) {
+        this.title = title;
+        this.content = content;
+        this.pinned = pinned;
+        this.important = important;
+    }
+
+    public void unmarkAsImportant() {
+        this.important = false;
+    }
+
+}

--- a/src/main/java/com/mos/backend/studynotices/entity/StudyNoticeErrorCode.java
+++ b/src/main/java/com/mos/backend/studynotices/entity/StudyNoticeErrorCode.java
@@ -1,0 +1,32 @@
+package com.mos.backend.studynotices.entity;
+
+import com.mos.backend.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+
+import java.util.Locale;
+
+@RequiredArgsConstructor
+public enum StudyNoticeErrorCode implements ErrorCode {
+    STUDY_NOTICE_NOT_EXISTS(HttpStatus.NOT_FOUND, "study-notice.not-exists");
+
+
+    private final HttpStatus httpStatus;
+    private final String messageKey;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getErrorName() {
+        return this.name();
+    }
+
+    @Override
+    public String getMessage(MessageSource messageSource) {
+        return messageSource.getMessage(messageKey, null, Locale.getDefault());
+    }
+}

--- a/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeJpaRepository.java
+++ b/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeJpaRepository.java
@@ -1,0 +1,18 @@
+package com.mos.backend.studynotices.infrastructure;
+
+import com.mos.backend.studynotices.entity.StudyNotice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyNoticeJpaRepository extends JpaRepository<StudyNotice, Long> {
+    @EntityGraph(attributePaths = {"user", "study"})
+    List<StudyNotice> findAllByStudyId(Long studyId);
+
+    Optional<StudyNotice> findByStudyIdAndImportantIsTrue(Long studyId);
+
+    @EntityGraph(attributePaths = {"user", "study"})
+    Optional<StudyNotice> findById(Long studyNoticeId);
+}

--- a/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeRepository.java
+++ b/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeRepository.java
@@ -1,0 +1,19 @@
+package com.mos.backend.studynotices.infrastructure;
+
+import com.mos.backend.studynotices.entity.StudyNotice;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyNoticeRepository {
+
+    StudyNotice save(StudyNotice studyNotice);
+
+    List<StudyNotice> findAllByStudyId(Long studyId);
+
+    Optional<StudyNotice> findByStudyIdAndImportantIsTrue(Long studyId);
+
+    Optional<StudyNotice> findById(Long studyNoticeId);
+
+    void deleteById(Long studyNoticeId);
+}

--- a/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/studynotices/infrastructure/StudyNoticeRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.mos.backend.studynotices.infrastructure;
+
+import com.mos.backend.studynotices.entity.StudyNotice;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyNoticeRepositoryImpl implements StudyNoticeRepository{
+
+    private final StudyNoticeJpaRepository studyNoticeJpaRepository;
+
+
+    @Override
+    public StudyNotice save(StudyNotice studyNotice) {
+        return studyNoticeJpaRepository.save(studyNotice);
+    }
+
+    @Override
+    public List<StudyNotice> findAllByStudyId(Long studyId) {
+        return studyNoticeJpaRepository.findAllByStudyId(studyId);
+    }
+
+    @Override
+    public Optional<StudyNotice> findByStudyIdAndImportantIsTrue(Long studyId) {
+        return studyNoticeJpaRepository.findByStudyIdAndImportantIsTrue(studyId);
+    }
+
+    @Override
+    public Optional<StudyNotice> findById(Long studyNoticeId) {
+        return studyNoticeJpaRepository.findById(studyNoticeId);
+    }
+
+    @Override
+    public void deleteById(Long studyNoticeId) {
+        studyNoticeJpaRepository.deleteById(studyNoticeId);
+    }
+}

--- a/src/main/java/com/mos/backend/studynotices/presentation/controller/StudyNoticeController.java
+++ b/src/main/java/com/mos/backend/studynotices/presentation/controller/StudyNoticeController.java
@@ -1,0 +1,76 @@
+package com.mos.backend.studynotices.presentation.controller;
+
+import com.mos.backend.studynotices.application.StudyNoticeService;
+import com.mos.backend.studynotices.application.responsedto.StudyNoticeResponseDto;
+import com.mos.backend.studynotices.presentation.requestdto.StudyNoticeCreateRequestDto;
+import com.mos.backend.studynotices.presentation.requestdto.StudyNoticeUpdateRequestDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class StudyNoticeController {
+
+    private final StudyNoticeService studyNoticeService;
+
+    /**
+     * 공지 생성
+     */
+
+    @PostMapping("/studies/{studyId}/notices")
+    @ResponseStatus(HttpStatus.CREATED)
+    public StudyNoticeResponseDto create(
+            @PathVariable Long studyId,
+            @RequestBody @Valid StudyNoticeCreateRequestDto requestDto,
+            @AuthenticationPrincipal Long currentUserId) {
+        return studyNoticeService.create(studyId, currentUserId, requestDto.getTitle(), requestDto.getContent(), requestDto.getPinned(), requestDto.getImportant());
+    }
+
+    /**
+     * 공지 수정
+     */
+
+    @PatchMapping("/studies/{studyId}/notices/{noticeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public StudyNoticeResponseDto update(
+            @PathVariable Long studyId,
+            @PathVariable Long noticeId,
+            @RequestBody @Valid StudyNoticeUpdateRequestDto requestDto) {
+        return studyNoticeService.update(studyId, noticeId, requestDto.getTitle(), requestDto.getContent(), requestDto.getPinned(), requestDto.getImportant());
+    }
+
+    /**
+     * 공지 삭제
+     */
+
+    @DeleteMapping("/studies/{studyId}/notices/{noticeId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long studyId, @PathVariable Long noticeId) {
+        studyNoticeService.delete(studyId, noticeId);
+    }
+
+    /**
+     * 공지 단 건 조회
+     */
+
+    @GetMapping("/studies/{studyId}/notices/{noticeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public StudyNoticeResponseDto readOne(@PathVariable Long studyId, @PathVariable Long noticeId) {
+        return studyNoticeService.readOne(studyId, noticeId);
+    }
+
+    /**
+     * 공지 다 건 조회
+     */
+
+    @GetMapping("/studies/{studyId}/notices")
+    @ResponseStatus(HttpStatus.OK)
+    public List<StudyNoticeResponseDto> readAll(@PathVariable Long studyId) {
+        return studyNoticeService.readAll(studyId);
+    }
+}

--- a/src/main/java/com/mos/backend/studynotices/presentation/requestdto/StudyNoticeCreateRequestDto.java
+++ b/src/main/java/com/mos/backend/studynotices/presentation/requestdto/StudyNoticeCreateRequestDto.java
@@ -1,0 +1,22 @@
+package com.mos.backend.studynotices.presentation.requestdto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StudyNoticeCreateRequestDto {
+
+    @NotBlank(message = "title은 비어있거나 공백일 수 없습니다.")
+    private String title;
+    private String content;
+    @NotNull(message = "pinned는 비어있거나 공백일 수 없습니다.")
+    private Boolean pinned;
+    @NotNull(message = "pinned는 비어있거나 공백일 수 없습니다.")
+    private Boolean important;
+
+}

--- a/src/main/java/com/mos/backend/studynotices/presentation/requestdto/StudyNoticeUpdateRequestDto.java
+++ b/src/main/java/com/mos/backend/studynotices/presentation/requestdto/StudyNoticeUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package com.mos.backend.studynotices.presentation.requestdto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StudyNoticeUpdateRequestDto {
+
+    @NotBlank(message = "title 비어있거나 공백일 수 없습니다.")
+    private String title;
+    private String content;
+    @NotNull(message = "pinned는 비어있거나 공백일 수 없습니다.")
+    private Boolean pinned;
+    @NotNull(message = "pinned는 비어있거나 공백일 수 없습니다.")
+    private Boolean important;
+
+}

--- a/src/main/java/com/mos/backend/users/application/UserService.java
+++ b/src/main/java/com/mos/backend/users/application/UserService.java
@@ -7,6 +7,7 @@ import com.mos.backend.studymaterials.application.UploadType;
 import com.mos.backend.studymaterials.application.fileuploader.Uploader;
 import com.mos.backend.users.application.responsedto.UserDetailRes;
 import com.mos.backend.users.entity.User;
+import com.mos.backend.users.infrastructure.respository.UserRepository;
 import com.mos.backend.users.presentation.requestdto.UserUpdateReq;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.amazonaws.util.StringUtils.isNullOrEmpty;
@@ -24,6 +27,7 @@ import static com.amazonaws.util.StringUtils.isNullOrEmpty;
 @Service
 public class UserService {
     private final EntityFacade entityFacade;
+    private final UserRepository userRepository;
     private final TokenUtil tokenUtil;
     private final Uploader uploader;
 
@@ -60,5 +64,9 @@ public class UserService {
         Long userId = tokenUtil.verifyRefreshToken(refreshToken);
 
         tokenUtil.addTokenToCookie(response, userId);
+    }
+
+    public List<User> findAllById(Set<Long> userIds) {
+        return userRepository.findAllById(userIds);
     }
 }

--- a/src/main/java/com/mos/backend/users/infrastructure/respository/UserRepository.java
+++ b/src/main/java/com/mos/backend/users/infrastructure/respository/UserRepository.java
@@ -3,7 +3,9 @@ package com.mos.backend.users.infrastructure.respository;
 import com.mos.backend.users.entity.OauthProvider;
 import com.mos.backend.users.entity.User;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserRepository {
     User save(User user);
@@ -11,4 +13,6 @@ public interface UserRepository {
     Optional<User> findByOauthProviderAndSocialId(OauthProvider oauthProvider, String socialId);
 
     Optional<User> findById(Long userId);
+
+    List<User> findAllById(Set<Long> userIds);
 }

--- a/src/main/java/com/mos/backend/users/infrastructure/respository/UserRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/users/infrastructure/respository/UserRepositoryImpl.java
@@ -5,7 +5,9 @@ import com.mos.backend.users.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,5 +28,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Optional<User> findById(Long userId) {
         return userJpaRepository.findById(userId);
+    }
+
+    @Override
+    public List<User> findAllById(Set<Long> userIds) {
+        return userJpaRepository.findAllById(userIds);
     }
 }

--- a/src/main/resources/messages/messages-error.properties
+++ b/src/main/resources/messages/messages-error.properties
@@ -106,3 +106,6 @@ study-chat-message.deserialization-failed=\uC5ED\uC9C1\uB82C\uD654\uC5D0 \uC2E4\
 
 # NotificationLog
 notification-log.not-found=\uC54C\uB9BC\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
+
+# StudyNotice
+study-notice.not-exists=공지 사항을 찾을 수 없습니다.

--- a/src/test/java/com/mos/backend/studynotices/application/StudyNoticeServiceTest.java
+++ b/src/test/java/com/mos/backend/studynotices/application/StudyNoticeServiceTest.java
@@ -1,0 +1,191 @@
+package com.mos.backend.studynotices.application;
+
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
+import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studynotices.application.responsedto.StudyNoticeResponseDto;
+import com.mos.backend.studynotices.entity.StudyNotice;
+import com.mos.backend.studynotices.entity.StudyNoticeErrorCode;
+import com.mos.backend.studynotices.infrastructure.StudyNoticeRepository;
+import com.mos.backend.users.application.UserService;
+import com.mos.backend.users.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StudyNoticeServiceTest {
+
+    @InjectMocks
+    private StudyNoticeService studyNoticeService;
+
+    @Mock
+    private StudyNoticeRepository studyNoticeRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private EntityFacade entityFacade;
+
+
+    @Test
+    @DisplayName("공지를 성공적으로 생성한다.")
+    void create_success() {
+        // given
+        Long studyId = 1L;
+        Long currentUserId = 1L;
+
+        String title = "테스트 공지 제목";
+        String content = "테스트 공지 내용";
+        boolean pinned = true;
+        boolean important = true;
+
+        Study study = mock(Study.class);
+        User user = mock(User.class);
+        doReturn(currentUserId).when(user).getId();
+        StudyNotice studyNotice = mock(StudyNotice.class);
+        doReturn(title).when(studyNotice).getTitle();
+        doReturn(content).when(studyNotice).getContent();
+        doReturn(pinned).when(studyNotice).isPinned();
+        doReturn(important).when(studyNotice).isImportant();
+
+        when(entityFacade.getStudy(studyId)).thenReturn(study);
+        when(entityFacade.getUser(currentUserId)).thenReturn(user);
+        when(studyNoticeRepository.save(any(StudyNotice.class))).thenReturn(studyNotice);
+
+        // when
+        StudyNoticeResponseDto studyNoticeResponseDto = studyNoticeService.create(studyId, currentUserId, title, content, pinned, important);
+
+        // then
+        assertThat(studyNoticeResponseDto.getStudyId()).isEqualTo(studyId);
+        assertThat(studyNoticeResponseDto.getCreatorId()).isEqualTo(currentUserId);
+        assertThat(studyNoticeResponseDto.getTitle()).isEqualTo(title);
+        assertThat(studyNoticeResponseDto.getContent()).isEqualTo(content);
+        assertThat(studyNoticeResponseDto.isPinned()).isEqualTo(pinned);
+        assertThat(studyNoticeResponseDto.isImportant()).isEqualTo(important);
+    }
+
+    @Test
+    @DisplayName("중요 공지 생성 시, 기존 중요 공지는 해제된다.")
+    void whenCreateImportantNotice_thenUnmarksOldOne() {
+
+        // given
+        Long studyId = 1L;
+        Long currentUserId = 1L;
+
+        String title = "테스트 공지 제목";
+        String content = "테스트 공지 내용";
+        boolean pinned = true;
+        boolean important = true;
+
+        Study study = mock(Study.class);
+        doReturn(studyId).when(study).getId();
+        User user = mock(User.class);
+        doReturn(currentUserId).when(user).getId();
+        StudyNotice studyNotice = mock(StudyNotice.class);
+        doReturn(title).when(studyNotice).getTitle();
+        doReturn(content).when(studyNotice).getContent();
+        doReturn(pinned).when(studyNotice).isPinned();
+        doReturn(important).when(studyNotice).isImportant();
+
+        StudyNotice oldImportantNotice = StudyNotice.create(study, user, title, content, pinned, important);
+
+        when(studyNoticeRepository.findByStudyIdAndImportantIsTrue(study.getId()))
+                .thenReturn(Optional.of(oldImportantNotice));
+        when(entityFacade.getStudy(studyId)).thenReturn(study);
+        when(entityFacade.getUser(currentUserId)).thenReturn(user);
+        when(studyNoticeRepository.save(any(StudyNotice.class))).thenReturn(studyNotice);
+
+        // when
+        studyNoticeService.create(studyId, currentUserId, "new title", "new content", false, true);
+
+        // then
+        assertThat(oldImportantNotice.isImportant()).isFalse(); // 기존 공지가 해제되었는지 확인
+        verify(studyNoticeRepository).save(any(StudyNotice.class));
+    }
+
+    @Test
+    @DisplayName("공지를 성공적으로 수정한다")
+    void update_success() {
+        // given
+        Long studyId = 1L;
+        Long studyNoticeId = 1L;
+
+        Long creatorId = 1L;
+        String creatorNickname = "creator";
+
+        Long modifierId = 1L;
+        String modifierNickname = "modifier";
+
+        String title = "테스트 공지 제목";
+        String content = "테스트 공지 내용";
+        boolean pinned = true;
+        boolean important = true;
+
+        String updateTitle = "업데이트 제목";
+        String updateContent = "업데이트 내용";
+        boolean updatePinned = false;
+        boolean updateImportant = false;
+
+        Study study = mock(Study.class);
+        User creator = mock(User.class);
+        User modifier = mock(User.class);
+
+        StudyNotice studyNotice = StudyNotice.create(study, creator, title, content, pinned, important);
+
+        doReturn(modifierNickname).when(modifier).getNickname();
+
+        doReturn(creatorId).when(creator).getId();
+        doReturn(creatorNickname).when(creator).getNickname();
+
+        StudyNotice originalStudyNotice = spy(studyNotice);
+        doReturn(modifierId).when(originalStudyNotice).getUpdatedBy();
+        doReturn(studyNoticeId).when(originalStudyNotice).getId();
+
+        when(studyNoticeRepository.findById(studyNoticeId)).thenReturn(Optional.of(originalStudyNotice));
+        when(entityFacade.getUser(modifierId)).thenReturn(modifier);
+
+        // when
+        StudyNoticeResponseDto updatedNotice = studyNoticeService.update(studyId, studyNoticeId, updateTitle, updateContent, updatePinned, updateImportant);
+
+        // then
+        assertThat(updatedNotice.getTitle()).isEqualTo(updateTitle);
+        assertThat(updatedNotice.getContent()).isEqualTo(updateContent);
+        assertThat(updatedNotice.isPinned()).isEqualTo(updatePinned);
+        assertThat(updatedNotice.isImportant()).isEqualTo(updateImportant);
+        assertThat(updatedNotice.getModifierId()).isEqualTo(modifierId);
+        assertThat(updatedNotice.getModifierNickname()).isEqualTo(modifierNickname);
+    }
+
+    @Test
+    @DisplayName("공지 수정 시 존재하지 않으면 mosException이 발생한다.")
+    void givenNotExistsNoticeId_WhenUpdateNotice_ThenMosException() {
+        // given
+        Long studyId = 1L;
+        Long studyNoticeId = 1L;
+
+        String updateTitle = "업데이트 제목";
+        String updateContent = "업데이트 내용";
+        boolean updatePinned = false;
+        boolean updateImportant = false;
+
+        when(studyNoticeRepository.findById(studyNoticeId)).thenReturn(Optional.empty());
+
+        // when
+        MosException mosException = assertThrows(MosException.class, () -> studyNoticeService.update(studyId, studyNoticeId, updateTitle, updateContent, updatePinned, updateImportant));
+
+        // then
+        assertThat(mosException.getErrorCode()).isEqualTo(StudyNoticeErrorCode.STUDY_NOTICE_NOT_EXISTS);
+    }
+}


### PR DESCRIPTION
## ⭐ Issue Number
> close #196 

<br>

## 📌 Tasks
1. 스터디 공지 엔티티 생성
2. 스터디 공지 api 개발
 - 생성, 수정, 삭제, 단 건 조회, 다 건 조회 개발
 - 스터디 공지 modifier 조회 시 유저 목록 조회 쿼리 최적화를 위한 유저 목록 조회 메서드 생성
3. 스터디 공지 쿼리 수정
 - 스터디 공지 조회 시 N+1 문제로 인해 EntityGraph 적용
4. 스터디 생성 후 연관 작업 이벤트 처리 시 StudyMember(Leader) 등록을 가장 우선 순위로 지정
5. 권한 검사 메서드에서 불필요한 쿼리 메서드 제거
6. 스터디 공지 관련 에러 정의

<br>
