### PR TITLE
Refactor/study like count #232

### DIFF
--- a/src/main/java/com/mos/backend/studies/application/responsedto/StudiesResponseDto.java
+++ b/src/main/java/com/mos/backend/studies/application/responsedto/StudiesResponseDto.java
@@ -23,9 +23,11 @@ public class StudiesResponseDto {
     private Integer maxStudyMembers;
     private Integer viewCount;
     private List<String> tags;
+    private Long likedCount;
+    private Boolean isLiked;
 
     public StudiesResponseDto(Long studyId, String title, Category category, MeetingType meetingType, ProgressStatus progressStatus,
-                              RecruitmentStatus recruitmentStatus, String  content, LocalDate recruitmentStartDate, LocalDate recruitmentEndDate, Long currentStudyMembers, Integer maxStudyMembers, Integer viewCount, StudyTag tags) {
+                              RecruitmentStatus recruitmentStatus, String  content, LocalDate recruitmentStartDate, LocalDate recruitmentEndDate, Long currentStudyMembers, Integer maxStudyMembers, Integer viewCount, StudyTag tags, Long likedCount, Boolean isLikedByMe) {
         this.id = studyId;
         this.title = title;
         this.category = category.getDescription();
@@ -39,9 +41,11 @@ public class StudiesResponseDto {
         this.maxStudyMembers = maxStudyMembers;
         this.viewCount = viewCount;
         this.tags = tags.toList();
+        this.likedCount = likedCount;
+        this.isLiked = isLikedByMe;
     }
 
-    public static StudiesResponseDto from(Study study, Long currentStudyMembers) {
+    public static StudiesResponseDto from(Study study, Long currentStudyMembers, Long likedCount, Boolean isLikedByMe) {
         StudiesResponseDto studiesResponseDto = new StudiesResponseDto();
         studiesResponseDto.id = study.getId();
         studiesResponseDto.title = study.getTitle();
@@ -56,6 +60,8 @@ public class StudiesResponseDto {
         studiesResponseDto.maxStudyMembers = study.getMaxStudyMemberCount();
         studiesResponseDto.viewCount = study.getViewCount();
         studiesResponseDto.tags = study.getTags().toList();
+        studiesResponseDto.likedCount = likedCount;
+        studiesResponseDto.isLiked = isLikedByMe;
         return studiesResponseDto;
     }
 

--- a/src/main/java/com/mos/backend/studies/application/responsedto/StudyCardListResponseDto.java
+++ b/src/main/java/com/mos/backend/studies/application/responsedto/StudyCardListResponseDto.java
@@ -14,5 +14,4 @@ public class StudyCardListResponseDto {
     private int currentPage;
     private int totalPages;
     private List<StudiesResponseDto> studies;
-    
 }

--- a/src/main/java/com/mos/backend/studies/application/responsedto/StudyResponseDto.java
+++ b/src/main/java/com/mos/backend/studies/application/responsedto/StudyResponseDto.java
@@ -1,6 +1,6 @@
 package com.mos.backend.studies.application.responsedto;
 
-import com.mos.backend.studies.entity.Study;
+import com.mos.backend.studies.entity.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,37 +14,40 @@ public class StudyResponseDto {
     private String title;
     private String subNotice;
     private String content;
-    private int currentStudyMemberCount;
-    private int maxStudyMemberCount;
+    private Long currentStudyMemberCount;
+    private Integer maxStudyMemberCount;
     private String category;
     private String schedule;
     private LocalDate recruitmentStartDate;
     private LocalDate recruitmentEndDate;
-    private int viewCount;
+    private Integer viewCount;
     private String recruitmentStatus;
     private String progressStatus;
     private String meetingType;
     private List<String> tags;
+    private Long likedCount;
+    private Boolean isLiked;
 
-    public static StudyResponseDto from(Study study, int currentStudyMemberCount) {
-        StudyResponseDto studyResponseDto = new StudyResponseDto();
-        studyResponseDto.id = study.getId();
-        studyResponseDto.title = study.getTitle();
-        studyResponseDto.subNotice = study.getNotice();
-        studyResponseDto.content = study.getContent();
-        studyResponseDto.currentStudyMemberCount = currentStudyMemberCount;
-        studyResponseDto.maxStudyMemberCount = study.getMaxStudyMemberCount();
-        studyResponseDto.category = study.getCategory().getDescription();
-        studyResponseDto.schedule = study.getSchedule();
-        studyResponseDto.recruitmentStartDate = study.getRecruitmentStartDate();
-        studyResponseDto.recruitmentEndDate = study.getRecruitmentEndDate();
-        studyResponseDto.viewCount = study.getViewCount();
-        studyResponseDto.recruitmentStatus = study.getRecruitmentStatus().getDescription();
-        studyResponseDto.progressStatus = study.getProgressStatus().getDescription();
-        studyResponseDto.meetingType = study.getMeetingType().getDescription();
-        studyResponseDto.tags = study.getTags().toList();
-        return studyResponseDto;
+    public StudyResponseDto(Long studyId, String title, String notice, String content, Long currentStudyMemberCount, Integer maxStudyMemberCount, Category category, String schedule,
+                            LocalDate recruitmentStartDate, LocalDate recruitmentEndDate, Integer viewCount, RecruitmentStatus recruitmentStatus, ProgressStatus progressStatus, MeetingType meetingType,
+                            StudyTag tags, Long likedCount, Boolean isLiked) {
+        this.id = studyId;
+        this.title = title;
+        this.subNotice = notice;
+        this.content = content;
+        this.currentStudyMemberCount = currentStudyMemberCount;
+        this.maxStudyMemberCount = maxStudyMemberCount;
+        this.category = category.getDescription();
+        this.schedule = schedule;
+        this.recruitmentStartDate = recruitmentStartDate;
+        this.recruitmentEndDate = recruitmentEndDate;
+        this.viewCount = viewCount;
+        this.recruitmentStatus = recruitmentStatus.getDescription();
+        this.progressStatus = progressStatus.getDescription();
+        this.meetingType = meetingType.getDescription();
+        this.tags = tags.toList();
+        this.likedCount = likedCount;
+        this.isLiked = isLiked;
     }
-
 }
 

--- a/src/main/java/com/mos/backend/studies/infrastructure/StudyRepository.java
+++ b/src/main/java/com/mos/backend/studies/infrastructure/StudyRepository.java
@@ -1,6 +1,7 @@
 package com.mos.backend.studies.infrastructure;
 
 import com.mos.backend.studies.application.responsedto.StudiesResponseDto;
+import com.mos.backend.studies.application.responsedto.StudyResponseDto;
 import com.mos.backend.studies.entity.Study;
 import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
 import com.mos.backend.users.entity.User;
@@ -16,11 +17,19 @@ public interface StudyRepository {
 
     void increaseViewCount(Long studyId);
 
+    // 스터디 다 건 조회 (카드)
     Page<StudiesResponseDto> findStudies(Long currentUserId, Pageable pageable, String categoryCond, String meetingTypeCond, String recruitmentStatusCond, String progressStatusCond, boolean liked);
 
     long count();
 
     void delete(Long studyId);
 
+    // 유저가 참여 중인 스터디 목록 조회
     List<UserStudiesResponseDto> readUserStudies(User user, String progressStatusCond, String participationStatusCond);
+
+    // 스터디 단 건 조회
+    StudyResponseDto getStudyDetails(Long studyId, Long currentUserId);
+
+    // 인기 스터디 상세 정보 조회
+    StudiesResponseDto getHotStudyDetails(Long studyId, Long currentUserId);
 }

--- a/src/main/java/com/mos/backend/studies/infrastructure/StudyRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/studies/infrastructure/StudyRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.mos.backend.studies.infrastructure;
 
 import com.mos.backend.studies.application.responsedto.StudiesResponseDto;
+import com.mos.backend.studies.application.responsedto.StudyResponseDto;
 import com.mos.backend.studies.entity.Study;
 import com.mos.backend.users.application.responsedto.UserStudiesResponseDto;
 import com.mos.backend.users.entity.User;
@@ -18,7 +19,6 @@ public class StudyRepositoryImpl implements StudyRepository{
 
     private final StudyJpaRepository studyJpaRepository;
     private final StudyQueryDslRepository studyQueryDSLRepository;
-
 
     @Override
     public Study save(Study study) {
@@ -53,5 +53,15 @@ public class StudyRepositoryImpl implements StudyRepository{
     @Override
     public List<UserStudiesResponseDto> readUserStudies(User user, String progressStatusCond, String participationStatusCond) {
         return studyQueryDSLRepository.readUserStudies(user, progressStatusCond, participationStatusCond);
+    }
+
+    @Override
+    public StudyResponseDto getStudyDetails(Long studyId, Long currentUserId) {
+        return studyQueryDSLRepository.getStudyDetails(studyId, currentUserId);
+    }
+
+    @Override
+    public StudiesResponseDto getHotStudyDetails(Long studyId, Long currentUserId) {
+        return studyQueryDSLRepository.getHotStudyDetails(studyId, currentUserId);
     }
 }

--- a/src/main/java/com/mos/backend/studies/presentation/controller/api/StudyController.java
+++ b/src/main/java/com/mos/backend/studies/presentation/controller/api/StudyController.java
@@ -39,8 +39,12 @@ public class StudyController {
 
     @GetMapping("/{studyId}")
     @ResponseStatus(HttpStatus.OK)
-    public StudyResponseDto get(@PathVariable Long studyId, HttpServletRequest httpServletRequest) {
-        return studyService.get(studyId, httpServletRequest);
+    public StudyResponseDto get(
+            @PathVariable Long studyId,
+            HttpServletRequest httpServletRequest,
+            @AuthenticationPrincipal Long currentUserId
+    ) {
+        return studyService.get(studyId, httpServletRequest, currentUserId);
     }
 
     /**
@@ -67,8 +71,9 @@ public class StudyController {
 
     @GetMapping("/hots")
     @ResponseStatus(HttpStatus.OK)
-    public List<StudiesResponseDto> getHotStudyList() {
-        return studyService.readHotStudies();
+    public List<StudiesResponseDto> getHotStudyList(
+            @AuthenticationPrincipal Long currentUserId) {
+        return studyService.readHotStudies(currentUserId);
     }
 
     /**
@@ -95,8 +100,12 @@ public class StudyController {
      */
     @PostMapping("/{studyId}/sub-notice")
     @ResponseStatus(HttpStatus.OK)
-    public StudyResponseDto updateSubNotice(@PathVariable Long studyId, @RequestBody StudySubNoticeRequestDto requestDto) {
-        return studyService.updateSubNotice(studyId, requestDto.getSubNotice());
+    public StudyResponseDto updateSubNotice(
+            @PathVariable Long studyId,
+            @RequestBody StudySubNoticeRequestDto requestDto,
+            @AuthenticationPrincipal Long currentUserId
+    ) {
+        return studyService.updateSubNotice(studyId, requestDto.getSubNotice(), currentUserId);
     }
 
     /**

--- a/src/main/java/com/mos/backend/userstudylikes/application/UserStudyLikeService.java
+++ b/src/main/java/com/mos/backend/userstudylikes/application/UserStudyLikeService.java
@@ -7,6 +7,7 @@ import com.mos.backend.hotstudies.entity.HotStudyEventType;
 import com.mos.backend.studies.entity.Study;
 import com.mos.backend.users.entity.User;
 import com.mos.backend.userstudylikes.application.event.StudyLikeEventPayload;
+import com.mos.backend.userstudylikes.application.response.UserStudyLikeResponseDto;
 import com.mos.backend.userstudylikes.entity.UserStudyLike;
 import com.mos.backend.userstudylikes.infrastructure.UserStudyLikeRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,23 +26,42 @@ public class UserStudyLikeService {
 
 
     @Transactional
-    public void like(Long studyId, Long userId) {
+    public UserStudyLikeResponseDto like(Long studyId, Long userId) {
         Study study = entityFacade.getStudy(studyId);
         User user = entityFacade.getUser(userId);
         if (!existsUserStudyLike(user, study)) {
             userStudyLikeRepository.save(UserStudyLike.create(user, study));
             eventPublisher.publishEvent(new Event<>(EventType.STUDY_LIKED, new StudyLikeEventPayload(HotStudyEventType.LIKE, studyId)));
         }
+        return new UserStudyLikeResponseDto(userId, studyId, userStudyLikeRepository.getLikedCountByStudyId(studyId));
     }
 
     @Transactional
-    public void unlike(Long studyId, Long userId) {
+    public UserStudyLikeResponseDto unlike(Long studyId, Long userId) {
         Study study = entityFacade.getStudy(studyId);
         User user = entityFacade.getUser(userId);
         if (existsUserStudyLike(user, study)) {
             userStudyLikeRepository.deleteByUserAndStudy(user, study);
             eventPublisher.publishEvent(new Event<>(EventType.STUDY_LIKE_CANCELED, new StudyLikeEventPayload(HotStudyEventType.LIKE_CANCEL, studyId)));
         }
+        return new UserStudyLikeResponseDto(userId, studyId, userStudyLikeRepository.getLikedCountByStudyId(studyId));
+    }
+
+    /**
+     * 스터디의 좋아요 수 조회
+     */
+    public Long getLikedCountByStudyId(Long studyId) {
+        return userStudyLikeRepository.getLikedCountByStudyId(studyId);
+    }
+
+    /**
+     * 현재 유저가 특정 스터디를 좋아요 했는지 확인
+     */
+    public boolean isLikedByMe(Long studyId, Long currentUserId) {
+        if (currentUserId == null) {
+            return false;
+        }
+        return userStudyLikeRepository.isLikedByMe(studyId, currentUserId);
     }
 
     private boolean existsUserStudyLike(User user, Study study) {

--- a/src/main/java/com/mos/backend/userstudylikes/application/response/UserStudyLikeResponseDto.java
+++ b/src/main/java/com/mos/backend/userstudylikes/application/response/UserStudyLikeResponseDto.java
@@ -1,0 +1,14 @@
+package com.mos.backend.userstudylikes.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserStudyLikeResponseDto {
+    Long userId;
+    Long studyId;
+    Long likedCount;
+}

--- a/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeQueryDslRepository.java
+++ b/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeQueryDslRepository.java
@@ -1,0 +1,36 @@
+package com.mos.backend.userstudylikes.infrastructure;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.mos.backend.userstudylikes.entity.QUserStudyLike.userStudyLike;
+
+@Repository
+@RequiredArgsConstructor
+public class UserStudyLikeQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Long getLikedCountByStudyId(Long studyId) {
+        return jpaQueryFactory
+                .select(userStudyLike.count())
+                .from(userStudyLike)
+                .where(
+                        userStudyLike.study.id.eq(studyId)
+                )
+                .fetchOne();
+    }
+
+    public boolean isLikedByMe(Long studyId, Long currentUserId) {
+        Integer fetchFirst = jpaQueryFactory
+                .selectOne()
+                .from(userStudyLike)
+                .where(
+                        userStudyLike.study.id.eq(studyId),
+                        userStudyLike.user.id.eq(currentUserId)
+                )
+                .fetchFirst();
+        return fetchFirst != null;
+    }
+}

--- a/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeRepository.java
+++ b/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeRepository.java
@@ -10,4 +10,8 @@ public interface UserStudyLikeRepository {
     void save(UserStudyLike userStudyLike);
 
     void deleteByUserAndStudy(User user, Study study);
+
+    Long getLikedCountByStudyId(Long studyId);
+
+    boolean isLikedByMe(Long studyId, Long currentUserId);
 }

--- a/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/userstudylikes/infrastructure/UserStudyLikeRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 public class UserStudyLikeRepositoryImpl implements UserStudyLikeRepository {
 
     private final UserStudyLikeJpaRepository userStudyLikeJpaRepository;
+    private final UserStudyLikeQueryDslRepository userStudyLikeQueryDslRepository;
 
     @Override
     public boolean existsUserStudyLikeByUserAndStudy(User user, Study study) {
@@ -25,5 +26,15 @@ public class UserStudyLikeRepositoryImpl implements UserStudyLikeRepository {
     @Override
     public void deleteByUserAndStudy(User user, Study study) {
         userStudyLikeJpaRepository.deleteByUserAndStudy(user, study);
+    }
+
+    @Override
+    public Long getLikedCountByStudyId(Long studyId) {
+        return userStudyLikeQueryDslRepository.getLikedCountByStudyId(studyId);
+    }
+
+    @Override
+    public boolean isLikedByMe(Long studyId, Long currentUserId) {
+        return userStudyLikeQueryDslRepository.isLikedByMe(studyId, currentUserId);
     }
 }

--- a/src/main/java/com/mos/backend/userstudylikes/presentation/controller/api/UserStudyLikeRepository.java
+++ b/src/main/java/com/mos/backend/userstudylikes/presentation/controller/api/UserStudyLikeRepository.java
@@ -1,6 +1,7 @@
 package com.mos.backend.userstudylikes.presentation.controller.api;
 
 import com.mos.backend.userstudylikes.application.UserStudyLikeService;
+import com.mos.backend.userstudylikes.application.response.UserStudyLikeResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,14 +14,14 @@ public class UserStudyLikeRepository {
     private final UserStudyLikeService userStudyLikeService;
 
     @PostMapping("/studies/{studyId}/likes")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void likes(@PathVariable Long studyId, @AuthenticationPrincipal Long userId) {
-        userStudyLikeService.like(studyId, userId);
+    @ResponseStatus(HttpStatus.OK)
+    public UserStudyLikeResponseDto likes(@PathVariable Long studyId, @AuthenticationPrincipal Long userId) {
+        return userStudyLikeService.like(studyId, userId);
     }
 
     @DeleteMapping("/studies/{studyId}/likes")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void unlikes(@PathVariable Long studyId, @AuthenticationPrincipal Long userId) {
-        userStudyLikeService.unlike(studyId, userId);
+    @ResponseStatus(HttpStatus.OK)
+    public UserStudyLikeResponseDto unlikes(@PathVariable Long studyId, @AuthenticationPrincipal Long userId) {
+        return userStudyLikeService.unlike(studyId, userId);
     }
 }

--- a/src/test/java/com/mos/backend/studies/application/StudyServiceTest.java
+++ b/src/test/java/com/mos/backend/studies/application/StudyServiceTest.java
@@ -211,12 +211,12 @@ class StudyServiceTest {
         when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("0.0.0.0");
 
         // when
-        StudyResponseDto studyResponseDto = studyService.get(study.getId(), httpServletRequest);
+        StudyResponseDto studyResponseDto = studyService.get(study.getId(), httpServletRequest, 1L);
 
         // then
         verify(viewCountService).handleViewCount(eq(study.getId()), anyString());
         verify(studyRepository).findById(study.getId());
-        assertNotNull(studyResponseDto);
+        verify(studyRepository).getStudyDetails(study.getId(), 1L);
     }
 
     @Test
@@ -231,7 +231,7 @@ class StudyServiceTest {
         when(studyRepository.findById(studyId)).thenReturn(Optional.empty());
 
         // when
-        MosException mosException = assertThrows(MosException.class, () -> studyService.get(studyId, httpServletRequest));
+        MosException mosException = assertThrows(MosException.class, () -> studyService.get(studyId, httpServletRequest, 1L));
 
         // then
         verify(viewCountService).handleViewCount(eq(studyId), anyString());


### PR DESCRIPTION
## ⭐ Issue Number
> close #232

<br>

## 📌 Tasks
1. 스터디 좋아요 관련 쿼리 추가
2. 좋아요, 좋아요 취소 반환 값 수정
3. 스터디 조회 쿼리 수정
4. 스터디 조회 반환 값 수정
5. 깨진 테스트 수정

<br>

## ETC
메인 페이지에서 스터디 목록 조회 시, 스터디의 좋아요 수와 현재 인증된 사용자가 좋아요를 눌렀는지 정보를 같이 내보낼 때 쿼리가 너무 많이 발생해서 해당 쿼리를 queryDSL로 한 쿼리로 해결할 수 있도록 수정했습니다.
