### PR TITLE
Feat/#246

### DIFF
--- a/src/main/java/com/mos/backend/common/config/WebSocketConfig.java
+++ b/src/main/java/com/mos/backend/common/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.mos.backend.common.config;
 
 import com.mos.backend.common.stomp.handler.AuthenticatedPrincipalHandshakeHandler;
+import com.mos.backend.common.stomp.interceptor.StompExceptionInterceptor;
 import com.mos.backend.common.stomp.interceptor.StompInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,15 +15,17 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-
     private final StompInterceptor stompInterceptor;
     private final AuthenticatedPrincipalHandshakeHandler authenticatedPrincipalHandshakeHandler;
+    private final StompExceptionInterceptor stompExceptionInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOriginPatterns("*")
                 .setHandshakeHandler(authenticatedPrincipalHandshakeHandler);
+
+        registry.setErrorHandler(stompExceptionInterceptor);
     }
 
     @Override

--- a/src/main/java/com/mos/backend/common/dto/ServerSideMessage.java
+++ b/src/main/java/com/mos/backend/common/dto/ServerSideMessage.java
@@ -1,0 +1,23 @@
+package com.mos.backend.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+public record ServerSideMessage(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String code,
+        String reason
+) {
+    public ServerSideMessage {
+        Objects.requireNonNull(reason, "reason must not be null");
+    }
+
+    public static ServerSideMessage of(String reason) {
+        return new ServerSideMessage(null, reason);
+    }
+
+    public static ServerSideMessage of(String code, String reason) {
+        return new ServerSideMessage(code, reason);
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
-package com.mos.backend.common.exception;
+package com.mos.backend.common.handler;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.mos.backend.common.exception.ClientException;
+import com.mos.backend.common.exception.ErrorCode;
+import com.mos.backend.common.exception.MosException;
 import com.mos.backend.users.entity.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
@@ -15,8 +18,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
-
     private final MessageSource messageSource;
+
     @ExceptionHandler(MosException.class)
     public ResponseEntity<String> handleMosException(MosException e) {
         ErrorCode errorCode = e.getErrorCode();

--- a/src/main/java/com/mos/backend/common/handler/WebSocketGlobalExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/WebSocketGlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.mos.backend.common.handler;
+
+import com.mos.backend.common.dto.ServerSideMessage;
+import com.mos.backend.common.exception.ErrorCode;
+import com.mos.backend.common.exception.MosException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.security.Principal;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class WebSocketGlobalExceptionHandler {
+    private final MessageSource messageSource;
+    private final SimpMessagingTemplate template;
+    private static final String ERROR_DESTINATION = "/sub/errors";
+
+    @MessageExceptionHandler(MosException.class)
+    public void handleGlobalErrorException(Principal principal, MosException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        ServerSideMessage serverSideMessage = ServerSideMessage.of(
+                String.valueOf(errorCode.getStatus().value()), errorCode.getMessage(messageSource)
+        );
+        log.error("handleGlobalErrorException: {}", serverSideMessage);
+        template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
+    }
+
+    @MessageExceptionHandler(RuntimeException.class)
+    public void handleRuntimeException(Principal principal, RuntimeException e) {
+        ServerSideMessage serverSideMessage = ServerSideMessage.of("500", e.getMessage());
+        log.error("handleRuntimeException: {}", serverSideMessage);
+
+        template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/StompCommandHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/StompCommandHandler.java
@@ -1,0 +1,12 @@
+package com.mos.backend.common.handler.command;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+public interface StompCommandHandler {
+    boolean isSupport(StompCommand command);
+
+    void handle(Message<?> message, StompHeaderAccessor accessor);
+}
+

--- a/src/main/java/com/mos/backend/common/handler/command/StompCommandHandlerFactory.java
+++ b/src/main/java/com/mos/backend/common/handler/command/StompCommandHandlerFactory.java
@@ -1,0 +1,35 @@
+package com.mos.backend.common.handler.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompCommandHandlerFactory {
+    private final Map<StompCommand, List<StompCommandHandler>> handlers = new EnumMap<>(StompCommand.class);
+
+    @Autowired
+    public StompCommandHandlerFactory(List<StompCommandHandler> allHandlers) {
+        allHandlers.forEach(this::registerHandler);
+        log.info("StompCommandHandlerFactory: handlers={}", handlers);
+    }
+
+    private void registerHandler(StompCommandHandler handler) {
+        Arrays.stream(StompCommand.values())
+                .filter(handler::isSupport)
+                .forEach(command -> {
+                    handlers.computeIfAbsent(command, k -> new ArrayList<>()).add(handler);
+                    log.info("Registered handler {} for command {}", handler.getClass().getSimpleName(), command);
+                });
+    }
+
+    public List<StompCommandHandler> getHandlers(StompCommand command) {
+        return handlers.getOrDefault(command, List.of());
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/connect/AuthenticateHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/connect/AuthenticateHandler.java
@@ -1,0 +1,19 @@
+package com.mos.backend.common.handler.command.connect;
+
+import com.mos.backend.common.utils.StompPrincipalUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticateHandler implements ConnectCommandHandler {
+
+    @Override
+    public void handle(Message<?> message, StompHeaderAccessor accessor) {
+        StompPrincipalUtil.validatePrincipal(accessor);
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/connect/ConnectCommandHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/connect/ConnectCommandHandler.java
@@ -1,0 +1,11 @@
+package com.mos.backend.common.handler.command.connect;
+
+import com.mos.backend.common.handler.command.StompCommandHandler;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public interface ConnectCommandHandler extends StompCommandHandler {
+    default boolean isSupport(StompCommand command) {
+        return StompCommand.CONNECT.equals(command);
+    }
+}
+

--- a/src/main/java/com/mos/backend/common/handler/command/disconnect/DisconnectCommandHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/disconnect/DisconnectCommandHandler.java
@@ -1,0 +1,10 @@
+package com.mos.backend.common.handler.command.disconnect;
+
+import com.mos.backend.common.handler.command.StompCommandHandler;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public interface DisconnectCommandHandler extends StompCommandHandler {
+    default boolean isSupport(StompCommand command) {
+        return StompCommand.DISCONNECT.equals(command);
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/disconnect/DisconnectHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/disconnect/DisconnectHandler.java
@@ -1,0 +1,54 @@
+package com.mos.backend.common.handler.command.disconnect;
+
+import com.mos.backend.common.stomp.entity.Subscription;
+import com.mos.backend.common.utils.StompPrincipalUtil;
+import com.mos.backend.common.utils.StompSessionUtil;
+import com.mos.backend.privatechatroommember.application.PrivateChatRoomMemberService;
+import com.mos.backend.privatechatrooms.application.PrivateChatRoomInfoService;
+import com.mos.backend.studychatrooms.application.StudyChatRoomInfoService;
+import com.mos.backend.studymembers.application.StudyMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class DisconnectHandler implements DisconnectCommandHandler {
+    private final PrivateChatRoomMemberService privateChatRoomMemberService;
+    private final PrivateChatRoomInfoService privateChatRoomInfoService;
+    private final StudyMemberService studyMemberService;
+    private final StudyChatRoomInfoService studyChatRoomInfoService;
+
+    @Override
+    public void handle(Message<?> message, StompHeaderAccessor accessor) {
+        Long userId = StompPrincipalUtil.getUserId(accessor);
+        if (Objects.isNull(userId)) return;
+
+        List<Subscription> subscriptions = StompSessionUtil.getAndRemoveAllSubscription(accessor);
+
+        subscriptions.forEach(
+                subscription -> {
+                    updateLastEntryAt(subscription, userId);
+                    resetChatRoomInfos(subscription, userId);
+                }
+        );
+    }
+
+    private void updateLastEntryAt(Subscription subscription, Long userId) {
+        switch (subscription.getType()) {
+            case PRIVATE_CHAT_ROOM -> privateChatRoomMemberService.updateLastEntryAt(userId, subscription.getId());
+            case STUDY_CHAT_ROOM -> studyMemberService.updateLastEntryAt(userId, subscription.getId());
+        }
+    }
+
+    private void resetChatRoomInfos(Subscription subscription, Long userId) {
+        switch (subscription.getType()) {
+            case PRIVATE_CHAT_ROOM -> privateChatRoomInfoService.resetChatRoomInfos(userId);
+            case STUDY_CHAT_ROOM -> studyChatRoomInfoService.resetChatRoomInfos(userId);
+        }
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/subscribe/SubscribeCommandHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/subscribe/SubscribeCommandHandler.java
@@ -1,0 +1,10 @@
+package com.mos.backend.common.handler.command.subscribe;
+
+import com.mos.backend.common.handler.command.StompCommandHandler;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public interface SubscribeCommandHandler extends StompCommandHandler {
+    default boolean isSupport(StompCommand command) {
+        return StompCommand.SUBSCRIBE.equals(command);
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/command/subscribe/SubscribeHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/subscribe/SubscribeHandler.java
@@ -1,0 +1,27 @@
+package com.mos.backend.common.handler.command.subscribe;
+
+import com.mos.backend.common.stomp.entity.Subscription;
+import com.mos.backend.common.utils.StompHeaderUtil;
+import com.mos.backend.common.utils.StompSessionUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Component
+public class SubscribeHandler implements SubscribeCommandHandler {
+    private static final String USER_DESTINATION_PREFIX = "/user";
+
+    @Override
+    public void handle(Message<?> message, StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (Objects.nonNull(destination) && destination.startsWith(USER_DESTINATION_PREFIX)) return;
+
+        Subscription subscription = StompHeaderUtil.parseDestination(destination);
+        StompSessionUtil.putSubscription(accessor, subscription);
+    }
+
+}

--- a/src/main/java/com/mos/backend/common/handler/command/unsubscribe/UnsubscribeCommandHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/unsubscribe/UnsubscribeCommandHandler.java
@@ -1,0 +1,11 @@
+package com.mos.backend.common.handler.command.unsubscribe;
+
+import com.mos.backend.common.handler.command.StompCommandHandler;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public interface UnsubscribeCommandHandler extends StompCommandHandler {
+    default boolean isSupport(StompCommand command) {
+        return StompCommand.UNSUBSCRIBE.equals(command);
+    }
+}
+

--- a/src/main/java/com/mos/backend/common/handler/command/unsubscribe/UnsubscribeHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/command/unsubscribe/UnsubscribeHandler.java
@@ -1,0 +1,49 @@
+package com.mos.backend.common.handler.command.unsubscribe;
+
+import com.mos.backend.common.stomp.entity.Subscription;
+import com.mos.backend.common.utils.StompPrincipalUtil;
+import com.mos.backend.common.utils.StompSessionUtil;
+import com.mos.backend.privatechatroommember.application.PrivateChatRoomMemberService;
+import com.mos.backend.privatechatrooms.application.PrivateChatRoomInfoService;
+import com.mos.backend.studychatrooms.application.StudyChatRoomInfoService;
+import com.mos.backend.studymembers.application.StudyMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UnsubscribeHandler implements UnsubscribeCommandHandler {
+    private final PrivateChatRoomMemberService privateChatRoomMemberService;
+    private final PrivateChatRoomInfoService privateChatRoomInfoService;
+    private final StudyMemberService studyMemberService;
+    private final StudyChatRoomInfoService studyChatRoomInfoService;
+
+    @Override
+    public void handle(Message<?> message, StompHeaderAccessor accessor) {
+        Optional<Subscription> optionalSubscription = StompSessionUtil.getAndRemoveSubscription(accessor);
+
+        optionalSubscription.ifPresent(subscription -> {
+            Long userId = StompPrincipalUtil.getUserId(accessor);
+            updateLastEntryAt(subscription, userId);
+            resetUnreadCount(subscription, userId);
+        });
+    }
+
+    private void updateLastEntryAt(Subscription subscription, Long userId) {
+        switch (subscription.getType()) {
+            case PRIVATE_CHAT_ROOM -> privateChatRoomMemberService.updateLastEntryAt(userId, subscription.getId());
+            case STUDY_CHAT_ROOM -> studyMemberService.updateLastEntryAt(userId, subscription.getId());
+        }
+    }
+
+    private void resetUnreadCount(Subscription subscription, Long userId) {
+        switch (subscription.getType()) {
+            case PRIVATE_CHAT_ROOM -> privateChatRoomInfoService.resetUnreadCount(userId, subscription.getId());
+            case STUDY_CHAT_ROOM -> studyChatRoomInfoService.resetUnreadCount(userId, subscription.getId());
+        }
+    }
+}

--- a/src/main/java/com/mos/backend/common/handler/exeption/GlobalExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/exeption/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.mos.backend.common.handler;
+package com.mos.backend.common.handler.exeption;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.mos.backend.common.exception.ClientException;

--- a/src/main/java/com/mos/backend/common/handler/exeption/WebSocketGlobalExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/handler/exeption/WebSocketGlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.mos.backend.common.handler;
+package com.mos.backend.common.handler.exeption;
 
 import com.mos.backend.common.dto.ServerSideMessage;
 import com.mos.backend.common.exception.ErrorCode;

--- a/src/main/java/com/mos/backend/common/redis/RedisSubscriber.java
+++ b/src/main/java/com/mos/backend/common/redis/RedisSubscriber.java
@@ -52,6 +52,11 @@ public class RedisSubscriber {
         }
     }
 
+    /**
+     * todo
+     * 채팅방 퇴장 시 unreadCnt=0으로 갱신 후, 업데이트 된 info를 해당 채팅방 유저에게 전송하기 위해 onPrivateChatRoomInfoMessage()를 호출하게 됨.
+     * 이 과정에서 unreadCnt=0였던 info가 privateChatRoomInfoService.updatePrivateChatRoomInfo()로 인해 1이 되는 버그 존재
+     */
     public void onPrivateChatRoomInfoMessage(String publishedMessage) {
         try {
             PrivateChatRoomInfoMessageDto privateChatRoomInfoMessageDto = objectMapper.readValue(publishedMessage, PrivateChatRoomInfoMessageDto.class);

--- a/src/main/java/com/mos/backend/common/stomp/handler/AbstractStompExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/stomp/handler/AbstractStompExceptionHandler.java
@@ -1,0 +1,68 @@
+package com.mos.backend.common.stomp.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mos.backend.common.dto.ServerSideMessage;
+import com.mos.backend.common.utils.StompMessageUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+/**
+ * STOMP 예외 처리를 위한 추상 기본 클래스.
+ * 이 클래스는 공통적인 예외 처리 로직을 제공하며, 구체적인 예외 처리 동작은 하위 클래스에서 구현합니다.
+ */
+@Slf4j
+public abstract class AbstractStompExceptionHandler implements StompExceptionHandler {
+    protected final ObjectMapper objectMapper;
+
+    public AbstractStompExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Message<byte[]> handle(Message<byte[]> clientMessage, Throwable cause) {
+        if (isNullReturnRequired(clientMessage)) {
+            return null;
+        }
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(getStompCommand());
+        accessor.setLeaveMutable(true);
+
+        extractReceiptId(clientMessage).ifPresent(accessor::setReceiptId);
+
+        ServerSideMessage payload = getServerSideMessage(cause);
+        if (payload != null) {
+            accessor.setMessage(payload.code());
+        }
+
+        accessor.setImmutable();
+        return StompMessageUtil.createMessage(accessor, payload, objectMapper);
+    }
+
+    /**
+     * 클라이언트 메시지의 유효성을 검사합니다.
+     * 기본 구현은 항상 false를 반환합니다. 필요한 경우 하위 클래스에서 재정의할 수 있습니다.
+     *
+     * @param clientMessage 클라이언트로부터 받은 원본 메시지
+     * @return null을 반환해야 한다면 true, 그렇지 않다면 false
+     */
+    protected boolean isNullReturnRequired(Message<byte[]> clientMessage) {
+        return false;
+    }
+
+    /**
+     * 이 핸들러가 사용할 STOMP 명령을 반환합니다.
+     *
+     * @return STOMP 명령
+     */
+    protected abstract StompCommand getStompCommand();
+
+    /**
+     * 주어진 예외를 기반으로 {@link ServerSideMessage}를 생성합니다.
+     *
+     * @param cause 발생한 예외
+     * @return 생성된 ServerSideMessage
+     */
+    protected abstract ServerSideMessage getServerSideMessage(Throwable cause);
+}

--- a/src/main/java/com/mos/backend/common/stomp/handler/AuthenticateExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/stomp/handler/AuthenticateExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.mos.backend.common.stomp.handler;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mos.backend.common.dto.ServerSideMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AuthenticateExceptionHandler extends AbstractStompExceptionHandler {
+    public AuthenticateExceptionHandler(ObjectMapper objectMapper) {
+        super(objectMapper);
+    }
+
+    @Override
+    public boolean canHandle(Throwable cause) {
+        return cause instanceof JWTVerificationException;
+    }
+
+    @Override
+    protected StompCommand getStompCommand() {
+        return StompCommand.ERROR;
+    }
+
+    @Override
+    protected ServerSideMessage getServerSideMessage(Throwable cause) {
+        JWTVerificationException e = (JWTVerificationException) cause;
+
+        log.warn("[JWT 인증 예외] {}", e.getMessage());
+
+        return ServerSideMessage.of(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage());
+    }
+}

--- a/src/main/java/com/mos/backend/common/stomp/handler/AuthenticatedPrincipalHandshakeHandler.java
+++ b/src/main/java/com/mos/backend/common/stomp/handler/AuthenticatedPrincipalHandshakeHandler.java
@@ -26,10 +26,13 @@ public class AuthenticatedPrincipalHandshakeHandler extends DefaultHandshakeHand
     protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
-            Long userId = getVerifiedUserId(httpServletRequest);
-            return () -> String.valueOf(userId);
+            try {
+                Long userId = getVerifiedUserId(httpServletRequest);
+                return () -> String.valueOf(userId);
+            } catch (Exception e) {
+                return null;
+            }
         }
-
         return null;
     }
 

--- a/src/main/java/com/mos/backend/common/stomp/handler/GlobalStompExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/stomp/handler/GlobalStompExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.mos.backend.common.stomp.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mos.backend.common.dto.ServerSideMessage;
+import com.mos.backend.common.exception.ErrorCode;
+import com.mos.backend.common.exception.MosException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class GlobalStompExceptionHandler extends AbstractStompExceptionHandler {
+    private final MessageSource messageSource;
+
+    public GlobalStompExceptionHandler(ObjectMapper objectMapper, MessageSource messageSource) {
+        super(objectMapper);
+        this.messageSource = messageSource;
+    }
+
+    @Override
+    public boolean canHandle(Throwable cause) {
+        return cause instanceof MosException;
+    }
+
+    @Override
+    protected StompCommand getStompCommand() {
+        return StompCommand.SEND;
+    }
+
+    @Override
+    protected ServerSideMessage getServerSideMessage(Throwable cause) {
+        MosException e = (MosException) cause;
+
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("[GlobalException] {}", e.getMessage());
+
+        return ServerSideMessage.of(String.valueOf(errorCode.getErrorName()), errorCode.getMessage(messageSource));
+    }
+}

--- a/src/main/java/com/mos/backend/common/stomp/handler/StompExceptionHandler.java
+++ b/src/main/java/com/mos/backend/common/stomp/handler/StompExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.mos.backend.common.stomp.handler;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+import java.util.Optional;
+
+public interface StompExceptionHandler {
+    /**
+     * 해당 예외를 처리할 수 있는지 여부를 반환하는 메서드
+     *
+     * @return true: 해당 예외를 처리할 수 있음, false: 해당 예외를 처리할 수 없음
+     */
+    boolean canHandle(Throwable cause);
+
+    /**
+     * 예외를 처리하는 메서드.
+     * WebSocket 프로토콜에 의해 ERROR 커맨드를 사용하면, client와의 연결을 반드시 끊어야 한다.
+     * 이를 원치 않는 경우, {@link StompCommand#ERROR}를 사용하여 Accessor를 설정해서는 안 된다.
+     *
+     * @param clientMessage {@link Message}: client로부터 받은 메시지
+     * @param cause         Throwable: 발생한 예외
+     * @return {@link Message}: client에게 보낼 최종 메시지
+     */
+    @Nullable
+    Message<byte[]> handle(@Nullable Message<byte[]> clientMessage, Throwable cause);
+
+    /**
+     * 클라이언트 메시지에서 receiptId를 추출합니다.
+     *
+     * @param clientMessage 클라이언트로부터 받은 원본 메시지 (null일 수 있음)
+     */
+    default Optional<String> extractReceiptId(Message<?> clientMessage) {
+        if (clientMessage != null) {
+            StompHeaderAccessor clientHeaderAccessor = MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
+            if (clientHeaderAccessor != null) {
+                String receiptId = clientHeaderAccessor.getReceipt();
+                return Optional.ofNullable(receiptId);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/mos/backend/common/stomp/interceptor/StompExceptionInterceptor.java
+++ b/src/main/java/com/mos/backend/common/stomp/interceptor/StompExceptionInterceptor.java
@@ -1,0 +1,35 @@
+package com.mos.backend.common.stomp.interceptor;
+
+import com.mos.backend.common.stomp.handler.StompExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompExceptionInterceptor extends StompSubProtocolErrorHandler {
+    private final List<StompExceptionHandler> interceptors;
+
+    @Override
+    @Nullable
+    public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
+        log.warn("STOMP client message processing error: {}", clientMessage);
+        Throwable cause = ex.getCause();
+
+        for (StompExceptionHandler interceptor : interceptors) {
+            if (interceptor.canHandle(cause)) {
+                log.warn("STOMP client message processing throw({}) catch handler {}", cause.getMessage(), interceptor);
+                return interceptor.handle(clientMessage, cause);
+            }
+        }
+
+        log.error("STOMP client message processing error: {}", ex.getMessage());
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+}

--- a/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
+++ b/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
@@ -1,108 +1,35 @@
 package com.mos.backend.common.stomp.interceptor;
 
-import com.mos.backend.common.stomp.entity.Subscription;
-import com.mos.backend.common.stomp.entity.SubscriptionType;
-import com.mos.backend.common.utils.StompHeaderUtil;
-import com.mos.backend.common.utils.StompPrincipalUtil;
-import com.mos.backend.common.utils.StompSessionUtil;
-import com.mos.backend.privatechatroommember.application.PrivateChatRoomMemberService;
-import com.mos.backend.privatechatrooms.application.PrivateChatRoomInfoService;
-import com.mos.backend.studychatrooms.application.StudyChatRoomInfoService;
-import com.mos.backend.studymembers.application.StudyMemberService;
+import com.mos.backend.common.handler.command.StompCommandHandler;
+import com.mos.backend.common.handler.command.StompCommandHandlerFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StompInterceptor implements ChannelInterceptor {
-
-    private final PrivateChatRoomInfoService privateChatRoomInfoService;
-    private final PrivateChatRoomMemberService privateChatRoomMemberService;
-    private final StudyMemberService studyMemberService;
-    private final StudyChatRoomInfoService studyChatRoomInfoService;
+    private final StompCommandHandlerFactory stompCommandHandlerFactory;
 
     @Override
-    public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-        StompCommand command = accessor.getCommand();
-        switch (command) {
-            case CONNECT -> handleConnect(accessor);
-            case SUBSCRIBE -> handleSubscribe(accessor);
-            case UNSUBSCRIBE -> handleUnsubscribe(accessor);
-            case DISCONNECT -> handleDisconnect(accessor);
+        if (accessor != null && accessor.getCommand() != null) {
+            log.info("[StompInboundInterceptor] command={}", accessor.getCommand());
+
+            for (StompCommandHandler handler : stompCommandHandlerFactory.getHandlers(accessor.getCommand())) {
+                handler.handle(message, accessor);
+            }
         }
 
         return message;
     }
-
-    private void handleConnect(StompHeaderAccessor accessor) {
-        StompPrincipalUtil.validatePrincipal(accessor);
-    }
-
-    private void handleSubscribe(StompHeaderAccessor accessor) {
-        String destination = accessor.getDestination();
-        if (Objects.nonNull(destination) && destination.startsWith("/user")) return;
-
-        Subscription subscription = StompHeaderUtil.parseDestination(destination);
-        if (subscription.getType() == SubscriptionType.PRIVATE_CHAT_ROOM
-                || subscription.getType() == SubscriptionType.STUDY_CHAT_ROOM) {
-            StompSessionUtil.putSubscription(accessor, subscription);
-        }
-    }
-
-    private void handleUnsubscribe(StompHeaderAccessor accessor) {
-        Optional<Subscription> optionalSubscription = StompSessionUtil.getAndRemoveSubscription(accessor);
-
-        optionalSubscription.ifPresent(subscription -> {
-            Long userId = StompPrincipalUtil.getUserId(accessor);
-            updateLastEntryAt(subscription, userId);
-            resetUnreadCount(subscription, userId);
-        });
-    }
-
-    private void handleDisconnect(StompHeaderAccessor accessor) {
-        Long userId = StompPrincipalUtil.getUserId(accessor);
-        if (Objects.isNull(userId)) return;
-
-        List<Subscription> subscriptions = StompSessionUtil.getAndRemoveAllSubscription(accessor);
-
-        subscriptions.forEach(
-                subscription -> {
-                    updateLastEntryAt(subscription, userId);
-                    resetChatRoomInfos(subscription, userId);
-                }
-        );
-    }
-
-    private void resetChatRoomInfos(Subscription subscription, Long userId) {
-        switch (subscription.getType()) {
-            case PRIVATE_CHAT_ROOM -> privateChatRoomInfoService.resetChatRoomInfos(userId);
-            case STUDY_CHAT_ROOM -> studyChatRoomInfoService.resetChatRoomInfos(userId);
-        }
-    }
-
-    private void updateLastEntryAt(Subscription subscription, Long userId) {
-        switch (subscription.getType()) {
-            case PRIVATE_CHAT_ROOM -> privateChatRoomMemberService.updateLastEntryAt(userId, subscription.getId());
-            case STUDY_CHAT_ROOM -> studyMemberService.updateLastEntryAt(userId, subscription.getId());
-        }
-    }
-
-    private void resetUnreadCount(Subscription subscription, Long userId) {
-        switch (subscription.getType()) {
-            case PRIVATE_CHAT_ROOM -> privateChatRoomInfoService.resetUnreadCount(userId, subscription.getId());
-            case STUDY_CHAT_ROOM -> studyChatRoomInfoService.resetUnreadCount(userId, subscription.getId());
-        }
-    }
-
 }

--- a/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
+++ b/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
@@ -18,6 +18,7 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -49,7 +50,10 @@ public class StompInterceptor implements ChannelInterceptor {
     }
 
     private void handleSubscribe(StompHeaderAccessor accessor) {
-        Subscription subscription = StompHeaderUtil.parseDestination(accessor);
+        String destination = accessor.getDestination();
+        if (Objects.nonNull(destination) && destination.startsWith("/user")) return;
+
+        Subscription subscription = StompHeaderUtil.parseDestination(destination);
         if (subscription.getType() == SubscriptionType.PRIVATE_CHAT_ROOM
                 || subscription.getType() == SubscriptionType.STUDY_CHAT_ROOM) {
             StompSessionUtil.putSubscription(accessor, subscription);

--- a/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
+++ b/src/main/java/com/mos/backend/common/stomp/interceptor/StompInterceptor.java
@@ -72,6 +72,8 @@ public class StompInterceptor implements ChannelInterceptor {
 
     private void handleDisconnect(StompHeaderAccessor accessor) {
         Long userId = StompPrincipalUtil.getUserId(accessor);
+        if (Objects.isNull(userId)) return;
+
         List<Subscription> subscriptions = StompSessionUtil.getAndRemoveAllSubscription(accessor);
 
         subscriptions.forEach(

--- a/src/main/java/com/mos/backend/common/utils/StompHeaderUtil.java
+++ b/src/main/java/com/mos/backend/common/utils/StompHeaderUtil.java
@@ -4,7 +4,6 @@ import com.mos.backend.common.exception.MosException;
 import com.mos.backend.common.stomp.entity.StompErrorCode;
 import com.mos.backend.common.stomp.entity.Subscription;
 import com.mos.backend.common.stomp.entity.SubscriptionType;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -12,8 +11,7 @@ import java.util.regex.Pattern;
 public class StompHeaderUtil {
     private static final Pattern DESTINATION_PATTERN = Pattern.compile("^(/user)?/sub/([a-zA-Z\\-]+)(?:/(\\d+))?$", Pattern.CASE_INSENSITIVE);
 
-    public static Subscription parseDestination(StompHeaderAccessor accessor) {
-        String destination = accessor.getDestination();
+    public static Subscription parseDestination(String destination) {
         if (destination == null) {
             throw new MosException(StompErrorCode.INVALID_DESTINATION);
         }

--- a/src/main/java/com/mos/backend/common/utils/StompHeaderUtil.java
+++ b/src/main/java/com/mos/backend/common/utils/StompHeaderUtil.java
@@ -4,6 +4,7 @@ import com.mos.backend.common.exception.MosException;
 import com.mos.backend.common.stomp.entity.StompErrorCode;
 import com.mos.backend.common.stomp.entity.Subscription;
 import com.mos.backend.common.stomp.entity.SubscriptionType;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -12,7 +13,7 @@ public class StompHeaderUtil {
     private static final Pattern DESTINATION_PATTERN = Pattern.compile("^(/user)?/sub/([a-zA-Z\\-]+)(?:/(\\d+))?$", Pattern.CASE_INSENSITIVE);
 
     public static Subscription parseDestination(String destination) {
-        if (destination == null) {
+        if (Strings.isEmpty(destination)) {
             throw new MosException(StompErrorCode.INVALID_DESTINATION);
         }
 

--- a/src/main/java/com/mos/backend/common/utils/StompMessageUtil.java
+++ b/src/main/java/com/mos/backend/common/utils/StompMessageUtil.java
@@ -1,0 +1,38 @@
+package com.mos.backend.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mos.backend.common.dto.ServerSideMessage;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+@Slf4j
+@UtilityClass
+public class StompMessageUtil {
+    private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+    /**
+     * StompHeaderAccessor와 페이로드를 사용하여 STOMP 메시지를 생성합니다.
+     *
+     * @param accessor     {@link StompHeaderAccessor}
+     * @param payload      메시지 페이로드 (null일 수 있음)
+     * @param objectMapper Jackson ObjectMapper
+     * @return 생성된 STOMP 메시지
+     */
+    public static Message<byte[]> createMessage(StompHeaderAccessor accessor, ServerSideMessage payload, ObjectMapper objectMapper) {
+        if (payload == null) {
+            return MessageBuilder.createMessage(EMPTY_PAYLOAD, accessor.getMessageHeaders());
+        }
+
+        try {
+            byte[] serializedPayload = objectMapper.writeValueAsBytes(payload);
+            return MessageBuilder.createMessage(serializedPayload, accessor.getMessageHeaders());
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing payload", e);
+            return MessageBuilder.createMessage(EMPTY_PAYLOAD, accessor.getMessageHeaders());
+        }
+    }
+}

--- a/src/main/java/com/mos/backend/common/utils/StompPrincipalUtil.java
+++ b/src/main/java/com/mos/backend/common/utils/StompPrincipalUtil.java
@@ -1,21 +1,22 @@
 package com.mos.backend.common.utils;
 
-import com.mos.backend.common.exception.MosException;
-import com.mos.backend.users.entity.exception.UserErrorCode;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
 import java.security.Principal;
+import java.util.Objects;
 
 public class StompPrincipalUtil {
 
     public static Long getUserId(StompHeaderAccessor accessor) {
-        return Long.valueOf(accessor.getUser().getName());
+        Principal user = accessor.getUser();
+        return Objects.isNull(user) ? null : Long.valueOf(user.getName());
     }
 
     public static void validatePrincipal(StompHeaderAccessor accessor) {
         Principal user = accessor.getUser();
         if (user == null || user.getName() == null) {
-            throw new MosException(UserErrorCode.USER_UNAUTHORIZED);
+            throw new JWTVerificationException("토큰이 유효하지 않습니다");
         }
     }
 }

--- a/src/main/java/com/mos/backend/common/utils/StompSessionUtil.java
+++ b/src/main/java/com/mos/backend/common/utils/StompSessionUtil.java
@@ -3,10 +3,7 @@ package com.mos.backend.common.utils;
 import com.mos.backend.common.stomp.entity.Subscription;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class StompSessionUtil {
     static final String SUBSCRIPTIONS = "SUBSCRIPTIONS";
@@ -24,7 +21,7 @@ public class StompSessionUtil {
         String subscriptionId = accessor.getSubscriptionId();
 
         Map<String, Subscription> subscriptionMap = (Map<String, Subscription>) accessor.getSessionAttributes().get(SUBSCRIPTIONS);
-        return Optional.ofNullable(subscriptionMap.remove(subscriptionId));
+        return Optional.ofNullable(Objects.isNull(subscriptionMap) ? null : subscriptionMap.remove(subscriptionId));
     }
 
     public static List<Subscription> getAndRemoveAllSubscription(StompHeaderAccessor accessor) {

--- a/src/main/java/com/mos/backend/privatechatmessages/application/PrivateChatMessageService.java
+++ b/src/main/java/com/mos/backend/privatechatmessages/application/PrivateChatMessageService.java
@@ -35,9 +35,9 @@ public class PrivateChatMessageService {
     private final PrivateChatRoomMemberService privateChatRoomMemberService;
 
     @Transactional
-    public void publish(Long userId, PrivateChatMessagePublishReq req) {
+    public void publish(Long userId, Long privateChatRoomId, PrivateChatMessagePublishReq req) {
         User user = entityFacade.getUser(userId);
-        PrivateChatRoom privateChatRoom = entityFacade.getPrivateChatRoom(req.getPrivateChatRoomId());
+        PrivateChatRoom privateChatRoom = entityFacade.getPrivateChatRoom(privateChatRoomId);
 
         privateChatRoom.visible();
 

--- a/src/main/java/com/mos/backend/privatechatmessages/presentation/controller/api/PrivateChatMessageController.java
+++ b/src/main/java/com/mos/backend/privatechatmessages/presentation/controller/api/PrivateChatMessageController.java
@@ -8,9 +8,11 @@ import com.mos.backend.privatechatmessages.presentation.req.PrivateChatMessagePu
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -18,11 +20,13 @@ import org.springframework.web.bind.annotation.*;
 public class PrivateChatMessageController {
     private final PrivateChatMessageService privateChatMessageService;
 
-    @MessageMapping("/private-chat-messages")
-    public void publishPrivateChatMessage(Message<?> message, PrivateChatMessagePublishReq privateChatMessagePublishReq) {
+    @MessageMapping("/privateChatRooms/{privateChatRoomId}/messages")
+    public void publishPrivateChatMessage(Message<?> message,
+                                          @DestinationVariable Long privateChatRoomId,
+                                          @Validated PrivateChatMessagePublishReq privateChatMessagePublishReq) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         Long userId = StompPrincipalUtil.getUserId(accessor);
-        privateChatMessageService.publish(userId, privateChatMessagePublishReq);
+        privateChatMessageService.publish(userId, privateChatRoomId, privateChatMessagePublishReq);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/mos/backend/privatechatmessages/presentation/req/PrivateChatMessagePublishReq.java
+++ b/src/main/java/com/mos/backend/privatechatmessages/presentation/req/PrivateChatMessagePublishReq.java
@@ -1,5 +1,7 @@
 package com.mos.backend.privatechatmessages.presentation.req;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PrivateChatMessagePublishReq {
-    private Long privateChatRoomId;
+    @NotNull(message = "메시지 내용은 Null을 허용하지 않습니다.")
+    @Size(min = 1, max = 1000, message = "메시지 내용은 1자 이상 1000자 이하로 입력해주세요.")
     private String message;
 }

--- a/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomInfoService.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomInfoService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
@@ -35,13 +36,15 @@ public class PrivateChatRoomInfoService {
     }
 
     public void resetUnreadCount(Long userId, Long privateChatRoomId) {
-        PrivateChatRoomInfo info = privateChatRoomInfoRepository.resetUnreadCount(userId, privateChatRoomId);
+        PrivateChatRoomInfo updatedInfo = privateChatRoomInfoRepository.resetUnreadCount(userId, privateChatRoomId);
 
-        PrivateChatRoomInfoMessageDto privateChatMessageDto = PrivateChatRoomInfoMessageDto.of(
-                userId, privateChatRoomId, info.getLastMessage(), info.getLastMessageAt()
-        );
+        if (Objects.nonNull(updatedInfo)) {
+            PrivateChatRoomInfoMessageDto privateChatMessageDto = PrivateChatRoomInfoMessageDto.of(
+                    userId, privateChatRoomId, updatedInfo.getLastMessage(), updatedInfo.getLastMessageAt()
+            );
 
-        redisPublisher.publishPrivateChatRoomInfoMessage(privateChatMessageDto);
+            redisPublisher.publishPrivateChatRoomInfoMessage(privateChatMessageDto);
+        }
     }
 
     public MyPrivateChatRoomRes updatePrivateChatRoomInfo(PrivateChatRoomInfoMessageDto dto) {

--- a/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomInfoService.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomInfoService.java
@@ -56,7 +56,7 @@ public class PrivateChatRoomInfoService {
                     privateChatRoomId, info.getChatName(), info.getLastMessage(), info.getLastMessageAt(), info.getUnreadCnt()
             );
         } catch (MosException e) {
-            if (e.getErrorCode() != PrivateChatRoomErrorCode.INFO_NOT_FOUND) {
+            if (e.getErrorCode() == PrivateChatRoomErrorCode.INFO_NOT_FOUND) {
                 PrivateChatRoomInfo info = savePrivateChatRoomInfo(privateChatRoomId, userId);
                 return MyPrivateChatRoomRes.of(
                         privateChatRoomId, info.getChatName(), info.getLastMessage(), info.getLastMessageAt(), info.getUnreadCnt()

--- a/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomService.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomService.java
@@ -51,7 +51,7 @@ public class PrivateChatRoomService {
     @Transactional(readOnly = true)
     public List<MyPrivateChatRoomRes> getMyPrivateChatRooms(Long userId) {
         User user = entityFacade.getUser(userId);
-        List<PrivateChatRoom> privateChatRooms = privateChatRoomRepository.findByUser(user);
+        List<PrivateChatRoom> privateChatRooms = privateChatRoomRepository.findByUserAndStatusIsVisible(user);
 
         List<MyPrivateChatRoomRes> myPrivateChatRoomResList = privateChatRooms.stream()
                 .map(privateChatRoom -> {

--- a/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomJpaRepository.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomJpaRepository.java
@@ -22,7 +22,7 @@ public interface PrivateChatRoomJpaRepository extends JpaRepository<PrivateChatR
     @Query("""
                 select m.privateChatRoom
                 from PrivateChatRoomMember m
-                where m.user = :user
+                where m.user = :user and m.privateChatRoom.status = 'VISIBLE'
             """)
-    List<PrivateChatRoom> findByUser(@Param("user") User user);
+    List<PrivateChatRoom> findByUserAndStatusIsVisible(@Param("user") User user);
 }

--- a/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomRepository.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomRepository.java
@@ -13,5 +13,5 @@ public interface PrivateChatRoomRepository {
 
     Optional<Long> findPrivateChatRoomIdByUsers(User user1, User user2);
 
-    List<PrivateChatRoom> findByUser(User user);
+    List<PrivateChatRoom> findByUserAndStatusIsVisible(User user);
 }

--- a/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomRepositoryImpl.java
+++ b/src/main/java/com/mos/backend/privatechatrooms/infrastructure/PrivateChatRoomRepositoryImpl.java
@@ -29,7 +29,7 @@ public class PrivateChatRoomRepositoryImpl implements PrivateChatRoomRepository 
     }
 
     @Override
-    public List<PrivateChatRoom> findByUser(User user) {
-        return privateChatRoomJpaRepository.findByUser(user);
+    public List<PrivateChatRoom> findByUserAndStatusIsVisible(User user) {
+        return privateChatRoomJpaRepository.findByUserAndStatusIsVisible(user);
     }
 }

--- a/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
+++ b/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
@@ -37,9 +37,9 @@ public class StudyChatMessageService {
     private final EntityFacade entityFacade;
 
     @Transactional
-    public void publish(Long userId, StudyChatMessagePublishReq req) {
+    public void publish(Long userId, Long studyId, StudyChatMessagePublishReq req) {
         User user = entityFacade.getUser(userId);
-        StudyChatRoom studyChatRoom = entityFacade.getStudyChatRoom(req.getStudyChatRoomId());
+        StudyChatRoom studyChatRoom = entityFacade.getStudyChatRoom(studyId);
 
         if (!studyMemberRepository.existsByUserAndStudy(user, studyChatRoom.getStudy()))
             throw new MosException(StudyChatRoomErrorCode.FORBIDDEN);

--- a/src/main/java/com/mos/backend/studychatmessages/presentation/controller/api/StudyChatMessageController.java
+++ b/src/main/java/com/mos/backend/studychatmessages/presentation/controller/api/StudyChatMessageController.java
@@ -7,8 +7,10 @@ import com.mos.backend.studychatmessages.application.res.StudyChatMessageRes;
 import com.mos.backend.studychatmessages.presentation.req.StudyChatMessagePublishReq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,11 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class StudyChatMessageController {
     private final StudyChatMessageService studyChatMessageService;
 
-    @MessageMapping("/study-chat-messages")
-    public void publishPrivateChatMessage(Message<?> message, StudyChatMessagePublishReq studyChatMessagePublishReq) {
+    @MessageMapping("/studies/{studyId}/messages")
+    public void publishPrivateChatMessage(Message<?> message,
+                                          @DestinationVariable Long studyId,
+                                          @Validated StudyChatMessagePublishReq studyChatMessagePublishReq) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         Long userId = StompPrincipalUtil.getUserId(accessor);
-        studyChatMessageService.publish(userId, studyChatMessagePublishReq);
+        studyChatMessageService.publish(userId, studyId, studyChatMessagePublishReq);
     }
 
     @GetMapping("/studies/{studyId}/chat-rooms/{studyChatRoomId}/messages")

--- a/src/main/java/com/mos/backend/studychatmessages/presentation/req/StudyChatMessagePublishReq.java
+++ b/src/main/java/com/mos/backend/studychatmessages/presentation/req/StudyChatMessagePublishReq.java
@@ -1,5 +1,7 @@
 package com.mos.backend.studychatmessages.presentation.req;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StudyChatMessagePublishReq {
-    private Long studyChatRoomId;
+    @NotNull(message = "메시지 내용은 Null을 허용하지 않습니다.")
+    @Size(min = 1, max = 1000, message = "메시지 내용은 1자 이상 1000자 이하로 입력해주세요.")
     private String message;
 }

--- a/src/test/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomServiceTest.java
+++ b/src/test/java/com/mos/backend/privatechatrooms/application/PrivateChatRoomServiceTest.java
@@ -117,7 +117,7 @@ class PrivateChatRoomServiceTest {
             PrivateChatMessage privateChatMessage = mock(PrivateChatMessage.class);
 
             when(entityFacade.getUser(userId)).thenReturn(user);
-            when(privateChatRoomRepository.findByUser(user)).thenReturn(List.of(privateChatRoom));
+            when(privateChatRoomRepository.findByUserAndStatusIsVisible(user)).thenReturn(List.of(privateChatRoom));
             when(privateChatMessageService.getLastMessage(privateChatRoom)).thenReturn(privateChatMessage);
 
             // When
@@ -125,7 +125,7 @@ class PrivateChatRoomServiceTest {
 
             // Then
             assertEquals(1, result.size());
-            verify(privateChatRoomRepository).findByUser(user);
+            verify(privateChatRoomRepository).findByUserAndStatusIsVisible(user);
         }
 
         @Test
@@ -136,14 +136,14 @@ class PrivateChatRoomServiceTest {
             User user = mock(User.class);
 
             when(entityFacade.getUser(userId)).thenReturn(user);
-            when(privateChatRoomRepository.findByUser(user)).thenReturn(Collections.emptyList());
+            when(privateChatRoomRepository.findByUserAndStatusIsVisible(user)).thenReturn(Collections.emptyList());
 
             // When
             List<MyPrivateChatRoomRes> result = privateChatRoomService.getMyPrivateChatRooms(userId);
 
             // Then
             assertTrue(result.isEmpty());
-            verify(privateChatRoomRepository).findByUser(user);
+            verify(privateChatRoomRepository).findByUserAndStatusIsVisible(user);
             verify(privateChatMessageRepository, never()).findFirstByPrivateChatRoomOrderByCreatedAtDesc(any(PrivateChatRoom.class));
         }
     }


### PR DESCRIPTION
## ⭐ Issue Number
> close #246

<br>

## 📌 Tasks
1. 메시지 전송 시 chatRoomId를 Body가 아닌 @DestinationValue로 처리하도록 개선
2. 앱 로직 중 발생하는 에러에 대해 @MessageExceptionHandler를 통한 예외 처리, /user/queue/errors를 통한 에러 응답 반환
3. stomp 프로토콜 레벨에서 발생하는 에러에 대한 예외 처리
4. 기존 StompInterceptor의 switch 기반 -> handler 기반 로직으로 개선

<br>

## ETC
더 전달할 내용이 있다면 여기에 작성해주세요.
