### PR TITLE
fix: 메시지 없는 채팅방 조회 시 NOT_FOUND 발생 버그 해결

### DIFF
--- a/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
+++ b/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
@@ -98,8 +98,7 @@ public class StudyChatMessageService {
         return studyChatMessageRepository.countByStudyChatRoomIdAndCreatedAtAfter(studyChatRoom.getId(), lastEntryAt);
     }
 
-    public StudyChatMessage getLastMessage(StudyChatRoom studyChatRoom) {
-        return studyChatMessageRepository.findFirstByStudyChatRoomOrderByCreatedAtDesc(studyChatRoom)
-                .orElseThrow(() -> new MosException(StudyChatMessageErrorCode.NOT_FOUND));
+    public Optional<StudyChatMessage> getLastMessage(StudyChatRoom studyChatRoom) {
+        return studyChatMessageRepository.findFirstByStudyChatRoomOrderByCreatedAtDesc(studyChatRoom);
     }
 }

--- a/src/main/java/com/mos/backend/studychatrooms/application/StudyChatRoomInfoService.java
+++ b/src/main/java/com/mos/backend/studychatrooms/application/StudyChatRoomInfoService.java
@@ -12,10 +12,12 @@ import com.mos.backend.studychatrooms.entity.StudyChatRoomErrorCode;
 import com.mos.backend.studychatrooms.entity.StudyChatRoomInfo;
 import com.mos.backend.studychatrooms.infrastructure.StudyChatRoomInfoRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -69,11 +71,13 @@ public class StudyChatRoomInfoService {
 
     public StudyChatRoomInfo saveStudyChatRoomInfo(Long studyChatRoomId, Long userId) {
         StudyChatRoom studyChatRoom = entityFacade.getStudyChatRoom(studyChatRoomId);
-        StudyChatMessage studyChatMessage = studyChatMessageService.getLastMessage(studyChatRoom);
+        Optional<StudyChatMessage> studyChatMessage = studyChatMessageService.getLastMessage(studyChatRoom);
         int unreadCount = studyChatMessageService.getUnreadCnt(userId, studyChatRoom.getId());
 
-        StudyChatRoomInfo info = StudyChatRoomInfo.of(
-                studyChatRoom.getName(), studyChatMessage.getMessage(), studyChatMessage.getCreatedAt(), unreadCount
+        StudyChatRoomInfo info = studyChatMessage.map(message ->
+                StudyChatRoomInfo.of(studyChatRoom.getName(), message.getMessage(), message.getCreatedAt(), unreadCount)
+        ).orElseGet(() ->
+                StudyChatRoomInfo.of(studyChatRoom.getName(), Strings.EMPTY, null, 0)
         );
         studyChatRoomInfoRepository.save(userId, studyChatRoomId, info);
 

--- a/src/main/java/com/mos/backend/studychatrooms/application/StudyChatRoomService.java
+++ b/src/main/java/com/mos/backend/studychatrooms/application/StudyChatRoomService.java
@@ -9,10 +9,12 @@ import com.mos.backend.studychatrooms.entity.StudyChatRoom;
 import com.mos.backend.studychatrooms.infrastructure.StudyChatRoomRepository;
 import com.mos.backend.users.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -41,15 +43,26 @@ public class StudyChatRoomService {
                 .map(studyChatRoom -> {
                     int unreadCount = studyChatMessageService.getUnreadCnt(user.getId(), studyChatRoom.getId());
 
-                    StudyChatMessage studyChatMessage = studyChatMessageService.getLastMessage(studyChatRoom);
+                    Optional<StudyChatMessage> optionalStudyChatMessage = studyChatMessageService.getLastMessage(studyChatRoom);
 
-                    return MyStudyChatRoomRes.of(
-                            studyChatRoom.getId(),
-                            studyChatRoom.getName(),
-                            studyChatMessage.getMessage(),
-                            studyChatMessage.getCreatedAt(),
-                            unreadCount
-                    );
+                    return optionalStudyChatMessage
+                            .map(studyChatMessage ->
+                                    MyStudyChatRoomRes.of(
+                                            studyChatRoom.getId(),
+                                            studyChatRoom.getName(),
+                                            studyChatMessage.getMessage(),
+                                            studyChatMessage.getCreatedAt(),
+                                            unreadCount
+                                    )
+                            ).orElseGet(() ->
+                                    MyStudyChatRoomRes.of(
+                                            studyChatRoom.getId(),
+                                            studyChatRoom.getName(),
+                                            Strings.EMPTY,
+                                            null,
+                                            unreadCount
+                                    )
+                            );
                 })
                 .toList();
 

--- a/src/test/java/com/mos/backend/studychatrooms/application/StudyChatRoomServiceTest.java
+++ b/src/test/java/com/mos/backend/studychatrooms/application/StudyChatRoomServiceTest.java
@@ -19,7 +19,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("StudyChatRoomService 테스트")
@@ -77,7 +79,7 @@ class StudyChatRoomServiceTest {
             when(studyChatRoomRepository.findAllByUserId(userId)).thenReturn(List.of(studyChatRoom));
             when(studyChatRoom.getId()).thenReturn(1L);
             when(studyChatMessageService.getUnreadCnt(userId, studyChatRoomId)).thenReturn(unreadCount);
-            when(studyChatMessageService.getLastMessage(studyChatRoom)).thenReturn(studyChatMessage);
+            when(studyChatMessageService.getLastMessage(studyChatRoom)).thenReturn(Optional.of(studyChatMessage));
 
             // When
             studyChatRoomService.getMyStudyChatRooms(userId);


### PR DESCRIPTION
- lastMessage 조회 시 Optional 반환을 통한 null 처리

## ⭐ Issue Number
> close #266

<br>

## 📌 Tasks
1. lastMessage 조회 반환을 Optional로 변경하여 메시지가 없는 채팅방 조회 시 발생하는 NOT_FOUND 해결

<br>

## ETC
더 전달할 내용이 있다면 여기에 작성해주세요.
