### PR TITLE
refactor: 스터디 채팅 메시지 조회 endpoint 변경

### DIFF
--- a/src/main/java/com/mos/backend/common/auth/StudyMemberSecurity.java
+++ b/src/main/java/com/mos/backend/common/auth/StudyMemberSecurity.java
@@ -1,0 +1,38 @@
+package com.mos.backend.common.auth;
+
+import com.mos.backend.common.exception.MosException;
+import com.mos.backend.common.infrastructure.EntityFacade;
+import com.mos.backend.studychatrooms.entity.StudyChatRoom;
+import com.mos.backend.users.entity.User;
+import com.mos.backend.users.entity.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component("studyMemberSecurity")
+@RequiredArgsConstructor
+public class StudyMemberSecurity {
+    private final EntityFacade entityFacade;
+
+    public boolean isMemberOrAdmin(long studyChatRoomId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        isAuthenticated(authentication);
+
+        Long currentUserId = Long.valueOf(authentication.getName());
+        User currentUser = entityFacade.getUser(currentUserId);
+
+        StudyChatRoom studyChatRoom = entityFacade.getStudyChatRoom(studyChatRoomId);
+
+        if (currentUser.isAdmin()) {
+            return true;
+        }
+        return entityFacade.getStudyMember(currentUserId, studyChatRoom.getStudy().getId()) != null;
+    }
+
+    private static void isAuthenticated(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new MosException(UserErrorCode.USER_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
+++ b/src/main/java/com/mos/backend/studychatmessages/application/StudyChatMessageService.java
@@ -8,7 +8,6 @@ import com.mos.backend.common.utils.InfinityScrollUtil;
 import com.mos.backend.studychatmessages.application.dto.StudyChatMessageDto;
 import com.mos.backend.studychatmessages.application.res.StudyChatMessageRes;
 import com.mos.backend.studychatmessages.entity.StudyChatMessage;
-import com.mos.backend.studychatmessages.entity.exception.StudyChatMessageErrorCode;
 import com.mos.backend.studychatmessages.infrastructure.StudyChatMessageRepository;
 import com.mos.backend.studychatmessages.presentation.req.StudyChatMessagePublishReq;
 import com.mos.backend.studychatrooms.application.dto.StudyChatRoomInfoMessageDto;
@@ -64,9 +63,9 @@ public class StudyChatMessageService {
         return studyChatMessageRepository.save(studyChatMessage);
     }
 
-    @PreAuthorize("@studySecurity.isMemberOrAdmin(#studyId)")
+    @PreAuthorize("@studyMemberSecurity.isMemberOrAdmin(#studyChatRoomId)")
     @Transactional(readOnly = true)
-    public InfinityScrollRes<StudyChatMessageRes> getStudyChatMessages(Long studyId, Long studyChatRoomId, Long lastStudyChatMessageId, Integer size) {
+    public InfinityScrollRes<StudyChatMessageRes> getStudyChatMessages(Long studyChatRoomId, Long lastStudyChatMessageId, Integer size) {
         StudyChatRoom studyChatRoom = entityFacade.getStudyChatRoom(studyChatRoomId);
 
         List<StudyChatMessage> studyChatMessages = studyChatMessageRepository.findAllByChatRoomIdForInfiniteScroll(

--- a/src/main/java/com/mos/backend/studychatmessages/presentation/controller/api/StudyChatMessageController.java
+++ b/src/main/java/com/mos/backend/studychatmessages/presentation/controller/api/StudyChatMessageController.java
@@ -30,11 +30,10 @@ public class StudyChatMessageController {
         studyChatMessageService.publish(userId, studyChatRoomId, studyChatMessagePublishReq);
     }
 
-    @GetMapping("/studies/{studyId}/chat-rooms/{studyChatRoomId}/messages")
-    public InfinityScrollRes<StudyChatMessageRes> getStudyChatMessages(@PathVariable Long studyId,
-                                                                       @PathVariable Long studyChatRoomId,
+    @GetMapping("/studies/chat-rooms/{studyChatRoomId}/messages")
+    public InfinityScrollRes<StudyChatMessageRes> getStudyChatMessages(@PathVariable Long studyChatRoomId,
                                                                        @RequestParam(required = false) Long lastStudyChatMessageId,
                                                                        @RequestParam(defaultValue = "10") Integer size) {
-        return studyChatMessageService.getStudyChatMessages(studyId, studyChatRoomId, lastStudyChatMessageId, size);
+        return studyChatMessageService.getStudyChatMessages(studyChatRoomId, lastStudyChatMessageId, size);
     }
 }

--- a/src/test/java/com/mos/backend/studychatmessages/application/StudyChatMessageServiceTest.java
+++ b/src/test/java/com/mos/backend/studychatmessages/application/StudyChatMessageServiceTest.java
@@ -52,10 +52,10 @@ class StudyChatMessageServiceTest extends AbstractTestContainer {
 
             // When
             InfinityScrollRes<StudyChatMessageRes> result1 = studyChatMessageService.getStudyChatMessages(
-                    study.getId(), studyChatRoom.getId(), lastStudyChatMessageId, size
+                    studyChatRoom.getId(), lastStudyChatMessageId, size
             );
             InfinityScrollRes<StudyChatMessageRes> result2 = studyChatMessageService.getStudyChatMessages(
-                    study.getId(), studyChatRoom.getId(), result1.getLastElementId(), size
+                    studyChatRoom.getId(), result1.getLastElementId(), size
             );
 
             // Then


### PR DESCRIPTION
## ⭐ Issue Number
> close #269

<br>

## 📌 Tasks
1. 채팅 메시지 조회 endpont 수정 (studyId 쿼리 파라미터 제거)
2. studyChatRoomId로 채팅 참가를 검증하기 위한 StudyMemberSecurity 구현

<br>

## ETC
더 전달할 내용이 있다면 여기에 작성해주세요.
