### PR TITLE
fix: JSON 응답에 hasNext 포함되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/mos/backend/common/dto/InfinityScrollRes.java
+++ b/src/main/java/com/mos/backend/common/dto/InfinityScrollRes.java
@@ -1,5 +1,6 @@
 package com.mos.backend.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -23,6 +24,7 @@ public class InfinityScrollRes<T> {
         return infinityScrollRes;
     }
 
+    @JsonProperty("hasNext")
     public boolean hasNext() {
         return hasNext;
     }


### PR DESCRIPTION
## ⭐ Issue Number
> close #275

<br>

## 📌 Tasks
1. @JsonProperty("hasNext") 적용


<br>

## ETC
더 전달할 내용이 있다면 여기에 작성해주세요.
